### PR TITLE
Auto-selecting translation, chapter and book

### DIFF
--- a/assets/js/BookSelector.js
+++ b/assets/js/BookSelector.js
@@ -1,8 +1,17 @@
 import React, {Component} from 'react';
 
 export default class BookSelector extends Component {
+    constructor(props) {
+        super(props);
+        this.onSelect = this.onSelect.bind(this);
+    }
+
+    onSelect(event) {
+        return this.props.changeSelectedBook(event.target.value)
+    }
+
     render() {
-        const {books, structure, isStructureLoaded, onBookSelectorChange} = this.props,
+        const {books, structure, isStructureLoaded, selectedBook} = this.props,
               options = [];
 
         if (isStructureLoaded) {
@@ -12,10 +21,10 @@ export default class BookSelector extends Component {
             });
 
             return (
-                <select className="form-control" onChange={(event) => onBookSelectorChange(event)}>
-                    {options.map((bookId) => {
-                        return (<option value={bookId} key={bookId}>{books[bookId].name}</option>);
-                    })}
+                <select className="form-control" onChange={this.onSelect} value={selectedBook}>
+                    {options.map((bookId) => (
+                        <option value={bookId} key={bookId}>{books[bookId].name}</option>
+                    ))}
                 </select>
             );
         } else

--- a/assets/js/ChapterSelector.js
+++ b/assets/js/ChapterSelector.js
@@ -1,21 +1,31 @@
 import React, {Component} from "react";
 
 export default class ChapterSelector extends Component {
+
+    constructor(props) {
+        super(props);
+        this.onSelect = this.onSelect.bind(this);
+    }
+
+    onSelect(event) {
+        return this.props.changeSelectedChapter(event.target.value)
+    }
+
     render() {
-        const {chapters, isStructureLoaded, onChapterSelectorChange} = this.props,
+        const {chapters, isStructureLoaded, selectedChapter} = this.props,
               options = [];
 
-        if (isStructureLoaded) {
+        if (isStructureLoaded && chapters && chapters.length) {
             // TODO: do we really need to repack those values, no other option to do it in more elegant way?
             chapters.forEach(chapterId => {
                 options.push(chapterId);
             });
 
             return (
-                <select className="form-control" onChange={(event) => onChapterSelectorChange(event)}>
-                    {options.map((chapterId) => {
-                        return (<option value={chapterId} key={chapterId}>{chapterId}</option>);
-                    })}
+                <select className="form-control" onChange={this.onSelect} value={selectedChapter}>
+                    {options.map((chapterId) => (
+                        <option value={chapterId} key={chapterId}>{chapterId}</option>
+                    ))}
                 </select>
             );
         } else

--- a/assets/js/Navigator.js
+++ b/assets/js/Navigator.js
@@ -6,29 +6,33 @@ import ChapterSelector from "./ChapterSelector";
 export default class Navigator extends Component {
     render() {
         const {translations, books, structure, chapters, isStructureLoaded,
-            onTranslationSelectorChange, onBookSelectorChange, onChapterSelectorChange} = this.props;
+            changeSelectedTranslation, changeSelectedBook, changeSelectedChapter,
+            selectedTranslation, selectedBook, selectedChapter} = this.props;
 
         return (
             <header className="row">
                 <div className="col-12 col-sm-4">
                     <TranslationSelector
+                        selectedTranslation={selectedTranslation}
                         translations={translations}
-                        onTranslationSelectorChange={onTranslationSelectorChange}
+                        changeSelectedTranslation={changeSelectedTranslation}
                     />
                 </div>
                 <div className="col-12 col-sm-4">
                     <BookSelector
+                        selectedBook={selectedBook}
                         books={books}
                         structure={structure}
                         isStructureLoaded={isStructureLoaded}
-                        onBookSelectorChange={onBookSelectorChange}
+                        changeSelectedBook={changeSelectedBook}
                     />
                 </div>
                 <div className="col-12 col-sm-4">
                     <ChapterSelector
+                        selectedChapter={selectedChapter}
                         chapters={chapters}
                         isStructureLoaded={isStructureLoaded}
-                        onChapterSelectorChange={onChapterSelectorChange}
+                        changeSelectedChapter={changeSelectedChapter}
                     />
                 </div>
             </header>

--- a/assets/js/Reader.js
+++ b/assets/js/Reader.js
@@ -5,7 +5,7 @@ export default class Reader extends Component {
     render() {
         const {selectedBook, selectedChapter, verses, showVerses} = this.props;
 
-        if (showVerses) {
+        if (showVerses && verses) {
             return (
                 <main className="row">
                     <div className="col-12">

--- a/assets/js/TranslationSelector.js
+++ b/assets/js/TranslationSelector.js
@@ -1,8 +1,19 @@
 import React, {Component} from "react";
 
 export default class TranslationSelector extends Component {
+
+    constructor(props) {
+        super(props);
+
+        this.onSelect = this.onSelect.bind(this);
+    }
+
+    onSelect(event) {
+        return this.props.changeSelectedTranslation(event.target.value)
+    }
+
     render() {
-        const {translations, onTranslationSelectorChange} = this.props,
+        const {translations, selectedTranslation} = this.props,
               translationList = [],
               map = {},
               languageNames = new Intl.DisplayNames(['pl'], {type: 'language'});
@@ -21,16 +32,14 @@ export default class TranslationSelector extends Component {
         });
 
         return (
-            <select className="form-control" onChange={(event) => onTranslationSelectorChange(event)}>
-                {translationList.map(({languageName, children}, key) => {
-                    return (
-                        <optgroup label={languageName} key={key}>{
-                            children.map(({id, name}) => (
-                                <option value={id} key={id}>{name}</option>
-                            ))
-                        }</optgroup>
-                    );
-                })}
+            <select className="form-control" onChange={this.onSelect} value={selectedTranslation}>
+                {translationList.map(({languageName, children}, key) => (
+                    <optgroup label={languageName} key={key}>{
+                        children.map(({id, name}) => (
+                            <option value={id} key={id}>{name}</option>
+                        ))
+                    }</optgroup>
+                ))}
             </select>
         );
     }


### PR DESCRIPTION
First of all, I make a select JSX elements controlled by react. It's mean that its value is dependent on the Bible component state properties. You can read more about it here: [https://reactjs.org/docs/forms.html ](https://reactjs.org/docs/forms.html )

Also, I made auto-select for:
- translation - default translation is Uwspółcześniona Biblia Gdańska
   - something what can be done - when the browser language is different than polish, the default translation can also be different.
- book - default book is 'joh' (John's Gospel) if exists for specific translation. If not, select the first existing book.
   - one comment here - I have noticed that you use object as a data structure for translations' chapters. It is not recommended, if you want to use the order of properties somewhere, because in JS and JSON, "An object is an **unordered** set of name/value pairs.". It's another quirky and not intuitive thing about JS. (more info: https://www.json.org/json-en.html ).
   So, we shouldn't trust property order as well as we can't change this order. But in a reality it should work correctly as it is.
- chapters - the default chapter is the first one in the structure

Still to do in my notes:
- make specific chapter accessible by URL. ex. /r/pl_bt5/gen/3
- show errors in more proper way
- optional:
   - make components more clean and readably by:
       - for example getting rid of 'state lifting up' and using redux 

