### PR TITLE
Making footer and header more sticky and stable

### DIFF
--- a/assets/js/Bible.js
+++ b/assets/js/Bible.js
@@ -295,7 +295,7 @@ class Bible extends Component {
             );
         } else {
             return (
-                <div className="container app">
+                <div className="app">
                     <Navigator
                         books={books}
                         translations={translations}

--- a/assets/js/Navigator.js
+++ b/assets/js/Navigator.js
@@ -20,30 +20,34 @@ export default class Navigator extends Component {
         } = this.props;
 
         return (
-            <header className="row">
-                <div className="col-12 col-sm-4">
-                    <TranslationSelector
-                        selectedTranslation={selectedTranslation}
-                        translations={translations}
-                        changeSelectedTranslation={changeSelectedTranslation}
-                    />
-                </div>
-                <div className="col-12 col-sm-4">
-                    <BookSelector
-                        selectedBook={selectedBook}
-                        books={books}
-                        structure={structure}
-                        isStructureLoaded={isStructureLoaded}
-                        changeSelectedBook={changeSelectedBook}
-                    />
-                </div>
-                <div className="col-12 col-sm-4">
-                    <ChapterSelector
-                        selectedChapter={selectedChapter}
-                        chapters={chapters}
-                        isStructureLoaded={isStructureLoaded}
-                        changeSelectedChapter={changeSelectedChapter}
-                    />
+            <header className="container sticky-top pt-2 pb-2">
+                <div className="row">
+                    <div className="col-12 col-sm-4">
+                        <TranslationSelector
+                            selectedTranslation={selectedTranslation}
+                            translations={translations}
+                            changeSelectedTranslation={
+                                changeSelectedTranslation
+                            }
+                        />
+                    </div>
+                    <div className="col-12 col-sm-4">
+                        <BookSelector
+                            selectedBook={selectedBook}
+                            books={books}
+                            structure={structure}
+                            isStructureLoaded={isStructureLoaded}
+                            changeSelectedBook={changeSelectedBook}
+                        />
+                    </div>
+                    <div className="col-12 col-sm-4">
+                        <ChapterSelector
+                            selectedChapter={selectedChapter}
+                            chapters={chapters}
+                            isStructureLoaded={isStructureLoaded}
+                            changeSelectedChapter={changeSelectedChapter}
+                        />
+                    </div>
                 </div>
             </header>
         );

--- a/assets/js/Reader.js
+++ b/assets/js/Reader.js
@@ -26,14 +26,6 @@ export default class Reader extends Component {
             );
         }
 
-        return (
-            <main className="container">
-                <div className="row">
-                    <div className="col-12 text-center m-auto">
-                        <div className="preloader-image"></div>
-                    </div>
-                </div>
-            </main>
-        );
+        return <main className="container preloader-image" />;
     }
 }

--- a/assets/js/Reader.js
+++ b/assets/js/Reader.js
@@ -8,26 +8,30 @@ export default class Reader extends Component {
 
         if (showVerses && verses) {
             return (
-                <main className="row">
-                    <div className="col-12">
-                        {Object.entries(verses).map((verse) => (
-                            <Verse
-                                key={verse[0]}
-                                bookId={selectedBook}
-                                chapterId={selectedChapter}
-                                verseId={verse[0]}
-                                verseContent={verse[1]}
-                            />
-                        ))}
+                <main className="container">
+                    <div className="row">
+                        <div className="col-12">
+                            {Object.entries(verses).map((verse) => (
+                                <Verse
+                                    key={verse[0]}
+                                    bookId={selectedBook}
+                                    chapterId={selectedChapter}
+                                    verseId={verse[0]}
+                                    verseContent={verse[1]}
+                                />
+                            ))}
+                        </div>
                     </div>
                 </main>
             );
         }
 
         return (
-            <main className="row">
-                <div className="col-12 text-center m-auto">
-                    <div className="preloader-image"></div>
+            <main className="container">
+                <div className="row">
+                    <div className="col-12 text-center m-auto">
+                        <div className="preloader-image"></div>
+                    </div>
                 </div>
             </main>
         );

--- a/assets/js/StatusBar.js
+++ b/assets/js/StatusBar.js
@@ -6,26 +6,28 @@ const StatusBar = ({ translations, setLocaleAndUpdateHistory }) => {
     const { formatMessage } = useIntl();
 
     return (
-        <footer className="row">
-            <div className="col-4">
-                <LanguageSelector
-                    setLocaleAndUpdateHistory={setLocaleAndUpdateHistory}
-                />
-            </div>
-            <div className="col-4 text-center">
-                <div className="d-none d-sm-inline">
-                    {formatMessage({ id: "availableTranslationsCounter" })}{" "}
+        <footer className="container sticky-bottom">
+            <div className="row">
+                <div className="col-4">
+                    <LanguageSelector
+                        setLocaleAndUpdateHistory={setLocaleAndUpdateHistory}
+                    />
                 </div>
-                {translations.length}
-            </div>
-            <div className="col-4 text-end">
-                <a
-                    href="/assets/changelog.txt"
-                    target="_blank"
-                    title={formatMessage({ id: "changelogLink" })}
-                >
-                    changelog.txt
-                </a>
+                <div className="col-4 text-center">
+                    <div className="d-none d-sm-inline">
+                        {formatMessage({ id: "availableTranslationsCounter" })}{" "}
+                    </div>
+                    {translations.length}
+                </div>
+                <div className="col-4 text-end">
+                    <a
+                        href="/assets/changelog.txt"
+                        target="_blank"
+                        title={formatMessage({ id: "changelogLink" })}
+                    >
+                        changelog.txt
+                    </a>
+                </div>
             </div>
         </footer>
     );

--- a/assets/js/StatusBar.js
+++ b/assets/js/StatusBar.js
@@ -6,7 +6,7 @@ const StatusBar = ({ translations, setLocaleAndUpdateHistory }) => {
     const { formatMessage } = useIntl();
 
     return (
-        <footer className="container sticky-bottom">
+        <footer className="container">
             <div className="row">
                 <div className="col-4">
                     <LanguageSelector

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -83,22 +83,16 @@ main {
 header,
 footer {
   @include rb-border;
-  position: sticky;
-  background: $rb-background-color;
 }
 
 header {
   background: $rb-header-background-color;
-  top: 0;
-  padding-bottom: 1em;
-  padding-top: 1em;
 }
 
 footer {
   background: $rb-footer-background-color;
   padding-top: 0.2em;
   padding-bottom: 0.2em;
-  bottom: 0;
 
   a {
     &:link,

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -93,6 +93,8 @@ footer {
   background: $rb-footer-background-color;
   padding-top: 0.2em;
   padding-bottom: 0.2em;
+  position: sticky;
+  bottom: 0;
 
   a {
     &:link,
@@ -106,11 +108,15 @@ footer {
 }
 
 .preloader-image {
+  height: 100%;
+  position: relative;
   &:before {
     width: 6em;
     height: 6em;
     content: "";
-    position: relative;
+    position: absolute;
+    top: calc(50% - 3em);
+    left: calc(50% - 3em);
     display: inline-block;
     overflow: hidden;
     transform-origin: 46% 54%;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "dev": "yarn encore dev --watch",
-    "eslint": "eslint assets"
+    "eslint": "eslint assets --fix"
   },
   "devDependencies": {
     "@babel/preset-react": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,8 @@
 {
+  "scripts": {
+    "dev": "yarn encore dev --watch",
+    "eslint": "eslint assets"
+  },
   "devDependencies": {
     "@babel/preset-react": "7.0.0",
     "@fontsource/open-sans": "^4.5.1",


### PR DESCRIPTION
- There was a conflict between `position:sticky` and bootstrap's container and row classes properties. Fixed!

- A few class have been uses instead of css properties.

- I made slightly smaller the padding at the top and bottom of Navigation container. If you want to keep the previous one - just change pb-2 and pt-2 to *-3.

Screenshot:
<img width="1183" alt="obraz" src="https://user-images.githubusercontent.com/16936376/189599890-5cb42452-57d0-45b2-b084-0b561b824c20.png">
