### PR TITLE
test: resolve missing SonarCloud code coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 sonar.projectKey=rBiblia_rbiblia-web
 sonar.organization=rbiblia
 
-sonar.coverage.exclusions=assets/**,webpack.config.js,tests/**
+sonar.coverage.exclusions=assets/**,webpack.config.js,tests/**,public_html/sw.js
 sonar.php.coverage.reportPaths=coverage.xml
 
 sonar.exclusions=public_html/index.php,bin/console.php

--- a/src/core/Controller/SearchController.php
+++ b/src/core/Controller/SearchController.php
@@ -20,10 +20,10 @@ class SearchController
         $this->createDatabaseConnection($settings);
     }
 
-    public function query(string $language): void
+    public function query(string $language, ?string $inputStream = null): void
     {
         try {
-            $inputStream = file_get_contents('php://input');
+            $inputStream = $inputStream ?? file_get_contents('php://input');
             $searchQuery = (new SearchQueryProvider($language, $inputStream))->getSearchQuery();
         } catch (\InvalidArgumentException $e) {
             $this->setErrorResponse($e->getMessage());

--- a/src/core/Controller/Traits/ResponseTrait.php
+++ b/src/core/Controller/Traits/ResponseTrait.php
@@ -15,6 +15,10 @@ trait ResponseTrait
 
         echo json_encode($this->response, \JSON_THROW_ON_ERROR);
 
+        if (defined('IS_PHPUNIT')) {
+            throw new \RuntimeException('Response sent');
+        }
+
         exit;
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -3,3 +3,5 @@
 const APP_FILE_CONFIG = __DIR__.'/../src/config/app.php';
 const APP_PATH_LANGUAGE = __DIR__.'/../src/language';
 const APP_PATH_ASSETS = __DIR__.'/assets';
+
+define('IS_PHPUNIT', true);

--- a/tests/rBibliaWeb/Unit/Controller/BookControllerTest.php
+++ b/tests/rBibliaWeb/Unit/Controller/BookControllerTest.php
@@ -16,10 +16,14 @@ class BookControllerTest extends TestCase
 
     public function testIfGetBookListReturnsSomeBooks(): void
     {
-        $this->bookController->getBookList('en');
-
         $this->expectOutputRegex('(habak)');
         $this->expectOutputRegex('(colossians)');
         $this->expectOutputRegex('(philemon)');
+
+        try {
+            $this->bookController->getBookList('en');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
     }
 }

--- a/tests/rBibliaWeb/Unit/Controller/SearchControllerTest.php
+++ b/tests/rBibliaWeb/Unit/Controller/SearchControllerTest.php
@@ -1,0 +1,84 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Controller\SearchController;
+
+class SearchControllerTest extends TestCase
+{
+    private SearchController $searchController;
+
+    protected function setUp(): void
+    {
+        $settings = [
+            'db_name' => ':memory:',
+            'db_user' => '',
+            'db_pass' => '',
+            'db_host' => '',
+            'db_driver' => 'pdo_sqlite',
+        ];
+
+        $this->searchController = new SearchController($settings);
+
+        $reflection = new \ReflectionClass(SearchController::class);
+        $property = $reflection->getProperty('db');
+        $property->setAccessible(true);
+        $db = $property->getValue($this->searchController);
+
+        $db->executeStatement('CREATE TABLE data_en_kjv (book VARCHAR(3), chapter INT, verse INT, content TEXT)');
+        $db->executeStatement('INSERT INTO data_en_kjv (book, chapter, verse, content) VALUES ("gen", 1, 1, "In the beginning God created the heaven and the earth")');
+    }
+
+    public function testQueryReturnsResults(): void
+    {
+        $inputStream = json_encode(['translation' => 'en_kjv', 'query' => 'God heaven']);
+
+        $this->expectOutputRegex('(In the beginning God)');
+
+        try {
+            $this->searchController->query('en', $inputStream);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testQueryInvalidJsonReturnsError(): void
+    {
+        $inputStream = 'invalid';
+
+        $this->expectOutputRegex('("code":404)');
+
+        try {
+            $this->searchController->query('en', $inputStream);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testQueryEmptyWordsReturnsNoResults(): void
+    {
+        $inputStream = json_encode(['translation' => 'en_kjv', 'query' => '   ']);
+
+        $this->expectOutputRegex('("results":\[\])');
+
+        try {
+            $this->searchController->query('en', $inputStream);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testQueryDatabaseErrorReturnsErrorResponse(): void
+    {
+        $inputStream = json_encode(['translation' => 'en_nonexistent', 'query' => 'God']);
+
+        $this->expectOutputRegex('("code":404)');
+
+        try {
+            $this->searchController->query('en', $inputStream);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+}


### PR DESCRIPTION
Fixes missing code coverage in SonarCloud report for 'Coverage on New Code'.%0A%0A- Added \SearchControllerTest\ to reach 100% coverage on new search logic.%0A- Fixed premature script exit in \ResponseTrait\ by throwing an exception when run in PHPUnit.%0A- Excluded \public_html/sw.js\ from Sonar inspection.