### PR TITLE
style: stack chapter comparison translation selectors on mobile

### DIFF
--- a/assets/images/icons/help-circle.svg
+++ b/assets/images/icons/help-circle.svg
@@ -1,0 +1,15 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <circle cx="12" cy="12" r="10" />
+  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+  <path d="M12 17h.01" />
+</svg>

--- a/assets/images/icons/mail.svg
+++ b/assets/images/icons/mail.svg
@@ -1,0 +1,14 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7" />
+  <rect x="2" y="4" width="20" height="16" rx="2" />
+</svg>

--- a/assets/images/icons/radio.svg
+++ b/assets/images/icons/radio.svg
@@ -1,0 +1,17 @@
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+  viewBox="0 0 24 24"
+  fill="none"
+  stroke="currentColor"
+  stroke-width="2"
+  stroke-linecap="round"
+  stroke-linejoin="round"
+>
+  <path d="M16.247 7.761a6 6 0 0 1 0 8.478" />
+  <path d="M19.075 4.933a10 10 0 0 1 0 14.134" />
+  <path d="M4.925 19.067a10 10 0 0 1 0-14.134" />
+  <path d="M7.753 16.239a6 6 0 0 1 0-8.478" />
+  <circle cx="12" cy="12" r="2" />
+</svg>

--- a/assets/images/icons/sprite.svg
+++ b/assets/images/icons/sprite.svg
@@ -42,6 +42,22 @@
   <path d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20" />
   <path d="M2 12h20" />
   </symbol>
+  <symbol id="help-circle" viewBox="0 0 24 24">
+<circle cx="12" cy="12" r="10" />
+  <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3" />
+  <path d="M12 17h.01" />
+  </symbol>
+  <symbol id="mail" viewBox="0 0 24 24">
+<path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7" />
+  <rect x="2" y="4" width="20" height="16" rx="2" />
+  </symbol>
+  <symbol id="radio" viewBox="0 0 24 24">
+<path d="M16.247 7.761a6 6 0 0 1 0 8.478" />
+  <path d="M19.075 4.933a10 10 0 0 1 0 14.134" />
+  <path d="M4.925 19.067a10 10 0 0 1 0-14.134" />
+  <path d="M7.753 16.239a6 6 0 0 1 0-8.478" />
+  <circle cx="12" cy="12" r="2" />
+  </symbol>
   <symbol id="search" viewBox="0 0 24 24">
 <path d="m21 21-4.34-4.34" />
   <circle cx="11" cy="11" r="8" />

--- a/assets/scss/app.scss
+++ b/assets/scss/app.scss
@@ -5002,6 +5002,17 @@ header.sticky-top {
   border-bottom: 1px solid #e5e7eb;
   flex-shrink: 0;
 
+  @media (max-width: 767px) {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.75rem;
+
+    .chapter-comp-vs {
+      align-self: center;
+      margin: -0.25rem 0;
+    }
+  }
+
   @include dark-mode {
     border-color: #333;
   }

--- a/public_html/sw.js
+++ b/public_html/sw.js
@@ -8,7 +8,7 @@
  *   - Images: Cache-first with network fallback
  */
 
-const CACHE_VERSION = "v1";
+const CACHE_VERSION = "v2";
 const STATIC_CACHE = `rbiblia-static-${CACHE_VERSION}`;
 const API_CACHE = `rbiblia-api-${CACHE_VERSION}`;
 const IMAGE_CACHE = `rbiblia-images-${CACHE_VERSION}`;
@@ -85,6 +85,12 @@ self.addEventListener("fetch", (event) => {
     // API requests → Network-first
     if (url.pathname.startsWith("/api/")) {
         event.respondWith(networkFirst(request, API_CACHE));
+        return;
+    }
+
+    // Keep sprite fresh to avoid stale icon symbols
+    if (url.pathname === "/assets/icons/sprite.svg") {
+        event.respondWith(networkFirst(request, STATIC_CACHE));
         return;
     }
 
@@ -205,3 +211,4 @@ function isStaticAsset(pathname) {
 function isImage(pathname) {
     return /\.(png|jpe?g|gif|webp|ico)(\?.*)?$/i.test(pathname);
 }
+


### PR DESCRIPTION
Fixes the layout of translation selectors in the chapter comparison tool to be more space-efficient on mobile. They are now stacked vertically, which prevents long translation names from overflowing or becoming difficult to read, while increasing the touch area size.