### PR TITLE
feat: UI refinements - mobile nav swapped, notes full translation name, expandable fix

### DIFF
--- a/assets/js/Bible.js
+++ b/assets/js/Bible.js
@@ -1,5 +1,11 @@
 /* global globalThis */
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from "react";
 import { getSigla } from "./bookSigla";
 import Navigator from "./Navigator";
 import Reader from "./Reader";
@@ -14,7 +20,12 @@ import ComparisonGrid from "./ComparisonGrid";
 import BottomNavigation from "./BottomNavigation";
 import useSwipeNavigation from "./useSwipeNavigation";
 import { SideMenu, SideMenuTab, DisplaySettings } from "./SideMenu";
-import { NotesPanel, NoteEditor } from "./Notes";
+import {
+    NotesPanel,
+    NoteEditor,
+    loadNotes,
+    loadTranslationNotes,
+} from "./Notes";
 import SearchPanel from "./SearchPanel";
 import ChapterComparison from "./ChapterComparison";
 import ChangelogModal from "./ChangelogModal";
@@ -135,10 +146,10 @@ const Bible = ({ intl, setLocale }) => {
     }, [fontFamily]);
 
     // Note: It contains all books available - not only translation specific
-    const [books, setBooks] = useState([]);
+    const [books, setBooks] = useState({});
     const [translations, setTranslations] = useState([]);
     const [structure, setStructure] = useState(null);
-    const [verses, setVerses] = useState([]);
+    const [verses, setVerses] = useState({});
     const [selectedTranslation, setSelectedTranslation] = useState(
         getDataFromCurrentPathname().translation
     );
@@ -155,7 +166,8 @@ const Bible = ({ intl, setLocale }) => {
             const data = getDataFromCurrentPathname();
             setSelectedTranslation(data.translation);
             setSelectedBook(data.book);
-            setSelectedChapter(data.chapter);
+            // Use changeSelectedChapter (not raw setter) so verses are actually fetched
+            changeSelectedChapter(data.chapter, data.book);
         };
 
         globalThis.addEventListener("popstate", handlePopState);
@@ -392,7 +404,6 @@ const Bible = ({ intl, setLocale }) => {
 
     const nextBook = () => {
         if (isNextBookAvailable()) {
-            setSelectedBook();
             changeSelectedBook(Object.keys(structure)[getBookIndex() + 1]);
         }
     };
@@ -405,12 +416,6 @@ const Bible = ({ intl, setLocale }) => {
 
         setSelectedBook(Object.keys(structure)[getBookIndex() - 1]);
     };
-
-    useEffect(() => {
-        if (startFromLastVerse.current) {
-            startFromLastVerse.current = false;
-        }
-    }, [selectedBook]);
 
     // Start critical fetches immediately on mount/change, independent of lists
     useEffect(() => {
@@ -460,6 +465,27 @@ const Bible = ({ intl, setLocale }) => {
         prevChapter, // ArrowLeft  → previous chapter
         nextChapter, // ArrowRight → next chapter
         { enabled: !overlaysOpen && showVerses }
+    );
+
+    // Load notes ONCE (not per-verse) — passed down to Reader → Verse
+    const allNotes = useMemo(() => loadNotes(), [notesVersion]);
+    const allTranslationNotes = useMemo(
+        () => loadTranslationNotes(),
+        [notesVersion]
+    );
+
+    // Stable callbacks for Reader → Verse (prevents memo breakage)
+    const handleVerseClick = useCallback(
+        (verseId) => setComparedVerse(verseId),
+        []
+    );
+    const handleVerseLongPress = useCallback(
+        (verseId) => setEditingNoteVerse(verseId),
+        []
+    );
+    const handleVerseCompare = useCallback(
+        (verseId) => setComparedVerse(verseId),
+        []
     );
 
     const handleNavigateToVerse = useCallback(
@@ -567,26 +593,32 @@ const Bible = ({ intl, setLocale }) => {
                 selectedBook={selectedBook}
                 selectedChapter={selectedChapter}
                 selectedTranslation={selectedTranslation}
+                translationName={
+                    translations?.find?.((t) => t.id === selectedTranslation)
+                        ?.name || selectedTranslation
+                }
                 verses={verses}
-                onVerseClick={(verseId) => setComparedVerse(verseId)}
-                onVerseLongPress={(verseId) => setEditingNoteVerse(verseId)}
-                onVerseCompare={(verseId) => setComparedVerse(verseId)}
+                onVerseClick={handleVerseClick}
+                onVerseLongPress={handleVerseLongPress}
+                onVerseCompare={handleVerseCompare}
                 notesVersion={notesVersion}
                 highlightedVerse={highlightedVerse}
+                allNotes={allNotes}
+                allTranslationNotes={allTranslationNotes}
             />
             <BottomNavigation
                 onPrevChapter={prevChapter}
                 onNextChapter={nextChapter}
                 onOpenSelection={() => setIsSelectionOpen(true)}
                 onOpenNotes={() => setIsNotesOpen(true)}
-                onOpenSearch={() => setIsSearchOpen(true)}
+                onOpenChapterComparison={() => setIsChapterCompOpen(true)}
                 isPrevAvailable={
                     isPrevChapterAvailable() || isPrevBookAvailable()
                 }
                 isNextAvailable={
                     isNextChapterAvailable() || isNextBookAvailable()
                 }
-                currentBook={books[selectedBook]?.name}
+                currentBook={getSigla(selectedBook, intl.locale)}
                 currentChapter={selectedChapter}
                 className={isNavVisible ? "" : "nav-hidden-bottom"}
             />
@@ -597,6 +629,7 @@ const Bible = ({ intl, setLocale }) => {
                 selectedBook={selectedBook}
                 selectedChapter={selectedChapter}
                 selectedTranslation={selectedTranslation}
+                translations={translations}
                 books={books}
                 onNavigateToVerse={handleNavigateToVerse}
             />

--- a/assets/js/BottomNavigation.js
+++ b/assets/js/BottomNavigation.js
@@ -7,7 +7,7 @@ const BottomNavigation = ({
     onNextChapter,
     onOpenSelection,
     onOpenNotes,
-    onOpenSearch,
+    onOpenChapterComparison,
     isPrevAvailable,
     isNextAvailable,
     currentBook,
@@ -56,15 +56,30 @@ const BottomNavigation = ({
                 </span>
             </button>
 
-            {/* Search - right of center */}
+            {/* Chapter Comparison - right of center */}
             <button
                 className="bottom-nav-btn"
-                onClick={onOpenSearch}
-                aria-label={formatMessage({ id: "search" })}
+                onClick={onOpenChapterComparison}
+                aria-label={formatMessage({ id: "chapterComparison" })}
             >
-                <Icon className="bottom-nav-icon" name="search" />
+                <svg
+                    className="bottom-nav-icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                >
+                    <path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
+                    <path d="m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
+                    <path d="M7 21h10" />
+                    <path d="M12 3v18" />
+                    <path d="M3 7h18" />
+                </svg>
                 <span className="bottom-nav-label">
-                    {formatMessage({ id: "search" })}
+                    {formatMessage({ id: "chapterComparisonShort" })}
                 </span>
             </button>
 

--- a/assets/js/ComparisonGrid.js
+++ b/assets/js/ComparisonGrid.js
@@ -1,10 +1,12 @@
-﻿import React, {
+﻿/* global globalThis */
+import React, {
     useEffect,
     useState,
     useCallback,
     useMemo,
     useRef,
 } from "react";
+import PropTypes from "prop-types";
 import { useIntl } from "react-intl";
 import {
     getComparisonLimit,
@@ -80,7 +82,7 @@ const computeLcsDiffIndices = (baseText, compareText, locale) => {
     const n = compareWords.length;
 
     // Build LCS DP table
-    const dp = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
+    const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
     for (let i = 1; i <= m; i++) {
         for (let j = 1; j <= n; j++) {
             if (baseWords[i - 1].word === compareWords[j - 1].word) {
@@ -151,7 +153,9 @@ const ComparisonGrid = ({
         const favorites = getAvailableFavorites();
         return [
             ...favorites,
-            ...Array(Math.max(0, comparisonLimit - favorites.length)).fill(""),
+            ...new Array(Math.max(0, comparisonLimit - favorites.length)).fill(
+                ""
+            ),
         ].slice(0, comparisonLimit);
     });
 
@@ -188,7 +192,7 @@ const ComparisonGrid = ({
                 .then((result) => {
                     // Only update if we're still on the same verse
                     if (currentVerseIdRef.current === forVerseId) {
-                        if (result.data && result.data[forVerseId]) {
+                        if (result?.data?.[forVerseId]) {
                             setComparedVerses((prev) => ({
                                 ...prev,
                                 [translationId]: result.data[forVerseId],
@@ -239,14 +243,16 @@ const ComparisonGrid = ({
         const favorites = getAvailableFavorites();
         const newSelections = [
             ...favorites,
-            ...Array(Math.max(0, comparisonLimit - favorites.length)).fill(""),
+            ...new Array(Math.max(0, comparisonLimit - favorites.length)).fill(
+                ""
+            ),
         ].slice(0, comparisonLimit);
         setSelectedTranslations(newSelections);
     }, [comparisonLimit]);
 
     // Convert to integers for comparison
-    const currentVerseNum = parseInt(verseId, 10);
-    const totalVersesNum = parseInt(totalVerses, 10);
+    const currentVerseNum = Number.parseInt(verseId, 10);
+    const totalVersesNum = Number.parseInt(totalVerses, 10);
 
     // Navigation handlers
     const handlePrevVerse = useCallback(() => {
@@ -468,8 +474,8 @@ const ComparisonGrid = ({
             }
         };
 
-        window.addEventListener("keydown", handleKeyDown);
-        return () => window.removeEventListener("keydown", handleKeyDown);
+        globalThis.addEventListener("keydown", handleKeyDown);
+        return () => globalThis.removeEventListener("keydown", handleKeyDown);
     }, [
         handlePrevVerse,
         handleNextVerse,
@@ -499,28 +505,8 @@ const ComparisonGrid = ({
         }
     };
 
-    // Get available translations for a specific selector
-    const getAvailableTranslations = (currentSlotIndex) => {
-        const usedTranslations = selectedTranslations.filter(
-            (t, i) => t && i !== currentSlotIndex
-        );
-        const available = translations.filter(
-            (t) =>
-                t.id !== currentTranslation && !usedTranslations.includes(t.id)
-        );
-
-        return available.sort((a, b) => {
-            const aIsFav = favoriteTranslations.includes(a.id);
-            const bIsFav = favoriteTranslations.includes(b.id);
-            if (aIsFav && !bIsFav) return -1;
-            if (!aIsFav && bIsFav) return 1;
-            return a.name.localeCompare(b.name);
-        });
-    };
-
     // Render translation selector
     const renderTranslationSelector = (index) => {
-        const available = getAvailableTranslations(index);
         const selectedId = selectedTranslations[index];
         const usedTranslations = selectedTranslations.filter(
             (t, i) => t && i !== index
@@ -543,46 +529,69 @@ const ComparisonGrid = ({
                     />
                 </div>
 
-                {selectedId && (
-                    <div className="comparison-box comparison-box-secondary mt-2">
-                        <div className="comparison-box-title">
-                            {
-                                translations.find((t) => t.id === selectedId)
-                                    ?.name
-                            }
-                        </div>
-                        {loading[selectedId] ? (
-                            <div className="comparison-loading">
-                                <div
-                                    className="spinner-border spinner-border-sm"
-                                    role="status"
-                                ></div>
+                {selectedId &&
+                    (() => {
+                        let content = null;
+                        if (loading[selectedId]) {
+                            content = (
+                                <div className="comparison-loading">
+                                    <output className="spinner-border spinner-border-sm"></output>
+                                </div>
+                            );
+                        } else if (comparedVerses[selectedId]) {
+                            content = (
+                                <p className="comparison-text">
+                                    {renderComparisonText(
+                                        comparedVerses[selectedId],
+                                        selectedId
+                                    )}
+                                </p>
+                            );
+                        } else if (comparedVerses[selectedId] === null) {
+                            content = (
+                                <p className="comparison-not-found">
+                                    {formatMessage({
+                                        id: "verseNotFoundInTranslation",
+                                    })}
+                                </p>
+                            );
+                        }
+
+                        return (
+                            <div className="comparison-box comparison-box-secondary mt-2">
+                                <div className="comparison-box-title">
+                                    {
+                                        translations.find(
+                                            (t) => t.id === selectedId
+                                        )?.name
+                                    }
+                                </div>
+                                {content}
                             </div>
-                        ) : comparedVerses[selectedId] ? (
-                            <p className="comparison-text">
-                                {renderComparisonText(
-                                    comparedVerses[selectedId],
-                                    selectedId
-                                )}
-                            </p>
-                        ) : comparedVerses[selectedId] === null ? (
-                            <p className="comparison-not-found">
-                                {formatMessage({
-                                    id: "verseNotFoundInTranslation",
-                                })}
-                            </p>
-                        ) : null}
-                    </div>
-                )}
+                        );
+                    })()}
             </div>
         );
     };
 
     return (
-        <div className="selection-overlay comparison-overlay" onClick={onClose}>
+        <div
+            className="selection-overlay comparison-overlay"
+            onClick={onClose}
+            onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                    onClose();
+                }
+            }}
+            role="button"
+            tabIndex={0}
+            aria-label={formatMessage({ id: "close" })}
+        >
             <div
                 className="selection-content container"
                 onClick={(e) => e.stopPropagation()}
+                onKeyDown={(e) => e.stopPropagation()}
+                role="presentation"
             >
                 <div className="selection-header d-flex justify-content-between align-items-center mb-4 pt-4">
                     {/* Navigation and title */}
@@ -663,13 +672,21 @@ const ComparisonGrid = ({
                                         id: "toggleDifferencesKeyboardHint",
                                     })}
                                 >
+                                    <span className="visually-hidden">
+                                        {formatMessage({
+                                            id: "toggleDifferences",
+                                        })}
+                                    </span>
                                     <input
                                         type="checkbox"
                                         checked={isDiffHighlightEnabled}
                                         onChange={toggleDiffHighlight}
                                     />
                                     <span className="rb-switch-slider">
-                                        <span className="rb-switch-text">
+                                        <span
+                                            className="rb-switch-text"
+                                            aria-hidden="true"
+                                        >
                                             {formatMessage({
                                                 id: "toggleDifferences",
                                             })}
@@ -686,10 +703,7 @@ const ComparisonGrid = ({
                                 </p>
                             ) : (
                                 <div className="comparison-loading">
-                                    <div
-                                        className="spinner-border spinner-border-sm"
-                                        role="status"
-                                    ></div>
+                                    <output className="spinner-border spinner-border-sm"></output>
                                 </div>
                             )}
                         </div>
@@ -709,6 +723,25 @@ const ComparisonGrid = ({
             </div>
         </div>
     );
+};
+
+ComparisonGrid.propTypes = {
+    verseId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired,
+    bookId: PropTypes.number.isRequired,
+    bookName: PropTypes.string.isRequired,
+    bookSigil: PropTypes.string.isRequired,
+    chapterId: PropTypes.number.isRequired,
+    currentTranslation: PropTypes.string.isRequired,
+    translations: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+        })
+    ).isRequired,
+    onClose: PropTypes.func.isRequired,
+    onNavigateVerse: PropTypes.func.isRequired,
+    totalVerses: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 };
 
 export default ComparisonGrid;

--- a/assets/js/Navigator.js
+++ b/assets/js/Navigator.js
@@ -56,12 +56,12 @@ export default function Navigator({
                     />
                 </div>
 
-                {/* Mobile action button (Chapter Comparison) */}
+                {/* Mobile action button (Search) */}
                 <div className="col-2 d-lg-none d-flex justify-content-end ps-0">
                     <button
                         className="nav-action-btn d-flex justify-content-center align-items-center"
-                        onClick={onOpenChapterComparison}
-                        title={formatMessage({ id: "chapterComparison" })}
+                        onClick={onOpenSearch}
+                        title={formatMessage({ id: "search" })}
                         style={{
                             width: "44px",
                             height: "44px",
@@ -79,11 +79,8 @@ export default function Navigator({
                             strokeLinecap="round"
                             strokeLinejoin="round"
                         >
-                            <path d="m16 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
-                            <path d="m2 16 3-8 3 8c-.87.65-1.92 1-3 1s-2.13-.35-3-1Z" />
-                            <path d="M7 21h10" />
-                            <path d="M12 3v18" />
-                            <path d="M3 7h18" />
+                            <circle cx="11" cy="11" r="8" />
+                            <path d="m21 21-4.35-4.35" />
                         </svg>
                     </button>
                 </div>

--- a/assets/js/Notes.js
+++ b/assets/js/Notes.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import PropTypes from "prop-types";
 import { useIntl } from "react-intl";
 import useFocusTrap from "./hooks/useFocusTrap";
 
@@ -134,11 +135,11 @@ const exportNotesXml = () => {
  */
 const escapeXml = (str) =>
     str
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&apos;");
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&apos;");
 
 /**
  * Import notes from rBiblia-compatible XML format
@@ -212,7 +213,7 @@ const downloadFile = (content, filename, mimeType) => {
     a.download = filename;
     document.body.appendChild(a);
     a.click();
-    document.body.removeChild(a);
+    a.remove();
     URL.revokeObjectURL(url);
 };
 
@@ -225,9 +226,16 @@ const NotesPanel = ({
     selectedBook,
     selectedChapter,
     selectedTranslation,
+    translations = [],
     books,
     onNavigateToVerse,
 }) => {
+    // Helper: resolve translationId to human-readable name
+    const getTranslationName = (id) => {
+        if (!id) return null;
+        const found = translations.find((t) => t.id === id);
+        return found ? found.name : id;
+    };
     const { formatMessage } = useIntl();
     const [notes, setNotes] = useState({});
     const [translationNotes, setTranslationNotes] = useState({});
@@ -387,7 +395,11 @@ const NotesPanel = ({
     // Navigate to verse
     const handleNavigate = (key, type) => {
         const { book, chapter, verse } = parseNoteKey(key, type);
-        onNavigateToVerse?.(book, parseInt(chapter), parseInt(verse));
+        onNavigateToVerse?.(
+            book,
+            Number.parseInt(chapter, 10),
+            Number.parseInt(verse, 10)
+        );
         onClose();
     };
 
@@ -407,10 +419,9 @@ const NotesPanel = ({
             const file = e.target.files?.[0];
             if (!file) return;
 
-            const reader = new FileReader();
-            reader.onload = (ev) => {
+            file.text().then((text) => {
                 try {
-                    importNotesXml(ev.target.result);
+                    importNotesXml(text);
                     // Reload notes
                     setNotes(loadNotes());
                     setTranslationNotes(loadTranslationNotes());
@@ -424,8 +435,7 @@ const NotesPanel = ({
                         text: formatMessage({ id: "importXmlError" }),
                     });
                 }
-            };
-            reader.readAsText(file);
+            });
         };
         input.click();
     };
@@ -436,6 +446,12 @@ const NotesPanel = ({
             <div
                 className={`notes-overlay ${isOpen ? "active" : ""}`}
                 onClick={onClose}
+                role="presentation"
+                onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        onClose();
+                    }
+                }}
             />
 
             {/* Panel */}
@@ -492,25 +508,22 @@ const NotesPanel = ({
                 {/* Filter tabs */}
                 <div className="notes-filter">
                     <button
-                        className={`notes-filter-btn ${
-                            filter === "current" ? "active" : ""
-                        }`}
+                        className={`notes-filter-btn ${filter === "current" ? "active" : ""
+                            }`}
                         onClick={() => setFilter("current")}
                     >
                         {formatMessage({ id: "currentChapter" })}
                     </button>
                     <button
-                        className={`notes-filter-btn ${
-                            filter === "all" ? "active" : ""
-                        }`}
+                        className={`notes-filter-btn ${filter === "all" ? "active" : ""
+                            }`}
                         onClick={() => setFilter("all")}
                     >
                         {formatMessage({ id: "allNotes" })}
                     </button>
                     <button
-                        className={`notes-filter-btn ${
-                            filter === "general" ? "active" : ""
-                        }`}
+                        className={`notes-filter-btn ${filter === "general" ? "active" : ""
+                            }`}
                         onClick={() => setFilter("general")}
                     >
                         {formatMessage({ id: "generalNotes" })}
@@ -745,21 +758,20 @@ const NotesPanel = ({
                                                                 {verse}
                                                             </button>
                                                             <span
-                                                                className={`note-type-badge ${
-                                                                    type ===
+                                                                className={`note-type-badge ${type ===
                                                                     "translation"
-                                                                        ? "note-type-translation"
-                                                                        : "note-type-global"
-                                                                }`}
+                                                                    ? "note-type-translation"
+                                                                    : "note-type-global"
+                                                                    }`}
                                                             >
                                                                 {type ===
-                                                                "translation"
-                                                                    ? translationId
+                                                                    "translation"
+                                                                    ? getTranslationName(translationId)
                                                                     : formatMessage(
-                                                                          {
-                                                                              id: "noteGlobal",
-                                                                          }
-                                                                      )}
+                                                                        {
+                                                                            id: "noteGlobal",
+                                                                        }
+                                                                    )}
                                                             </span>
                                                         </div>
                                                         <div className="note-actions">
@@ -882,6 +894,26 @@ const NotesPanel = ({
     );
 };
 
+NotesPanel.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    selectedBook: PropTypes.string,
+    selectedChapter: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    selectedTranslation: PropTypes.string,
+    translations: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            name: PropTypes.string.isRequired,
+        })
+    ),
+    books: PropTypes.objectOf(
+        PropTypes.shape({
+            name: PropTypes.string.isRequired,
+        })
+    ).isRequired,
+    onNavigateToVerse: PropTypes.func.isRequired,
+};
+
 /**
  * Note Editor Modal - for adding/editing a note on a specific verse
  * Now supports both global and translation-specific notes via tabs
@@ -955,6 +987,12 @@ const NoteEditor = ({
             <div
                 className={`note-editor-overlay ${isOpen ? "active" : ""}`}
                 onClick={onClose}
+                role="presentation"
+                onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        onClose();
+                    }
+                }}
             />
             <div
                 ref={modalRef}
@@ -981,9 +1019,8 @@ const NoteEditor = ({
                 {/* Tabs for global vs translation note */}
                 <div className="note-editor-tabs">
                     <button
-                        className={`note-editor-tab ${
-                            activeTab === "global" ? "active" : ""
-                        }`}
+                        className={`note-editor-tab ${activeTab === "global" ? "active" : ""
+                            }`}
                         onClick={() => setActiveTab("global")}
                     >
                         <svg
@@ -1003,9 +1040,8 @@ const NoteEditor = ({
                     </button>
                     {translationId && (
                         <button
-                            className={`note-editor-tab ${
-                                activeTab === "translation" ? "active" : ""
-                            }`}
+                            className={`note-editor-tab ${activeTab === "translation" ? "active" : ""
+                                }`}
                             onClick={() => setActiveTab("translation")}
                         >
                             <svg
@@ -1066,6 +1102,18 @@ const NoteEditor = ({
             </div>
         </>
     );
+};
+
+NoteEditor.propTypes = {
+    isOpen: PropTypes.bool.isRequired,
+    onClose: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
+    book: PropTypes.string,
+    chapter: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    verse: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    bookName: PropTypes.string,
+    translationId: PropTypes.string,
+    translationName: PropTypes.string,
 };
 
 /**

--- a/assets/js/Reader.js
+++ b/assets/js/Reader.js
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from "prop-types";
 import Verse from "./Verse";
 import SkeletonLoader from "./SkeletonLoader";
 
@@ -6,6 +7,7 @@ const Reader = ({
     selectedBook,
     selectedChapter,
     selectedTranslation,
+    translationName,
     verses,
     showVerses,
     onVerseClick,
@@ -13,6 +15,8 @@ const Reader = ({
     onVerseCompare,
     notesVersion = 0,
     highlightedVerse = null,
+    allNotes = {},
+    allTranslationNotes = {},
 }) => {
     if (!showVerses || !verses) {
         return <SkeletonLoader lines={15} />;
@@ -29,18 +33,37 @@ const Reader = ({
                             chapterId={selectedChapter}
                             verseId={verseId}
                             translationId={selectedTranslation}
+                            translationName={translationName}
                             verseContent={verseContent}
-                            onClick={() => onVerseClick(verseId)}
-                            onLongPress={() => onVerseLongPress?.(verseId)}
-                            onCompare={() => onVerseCompare?.(verseId)}
+                            onVerseClick={onVerseClick}
+                            onVerseLongPress={onVerseLongPress}
+                            onVerseCompare={onVerseCompare}
                             notesVersion={notesVersion}
                             isHighlighted={highlightedVerse === verseId}
+                            allNotes={allNotes}
+                            allTranslationNotes={allTranslationNotes}
                         />
                     ))}
                 </div>
             </div>
         </main>
     );
+};
+
+Reader.propTypes = {
+    selectedBook: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    selectedChapter: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    selectedTranslation: PropTypes.string,
+    translationName: PropTypes.string,
+    verses: PropTypes.objectOf(PropTypes.string),
+    showVerses: PropTypes.bool,
+    onVerseClick: PropTypes.func.isRequired,
+    onVerseLongPress: PropTypes.func,
+    onVerseCompare: PropTypes.func,
+    notesVersion: PropTypes.number,
+    highlightedVerse: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    allNotes: PropTypes.object,
+    allTranslationNotes: PropTypes.object,
 };
 
 export default Reader;

--- a/assets/js/SelectionGrid.js
+++ b/assets/js/SelectionGrid.js
@@ -16,11 +16,18 @@ const SelectionGrid = ({
     const [selectedBook, setSelectedBook] = useState(initialBook);
     const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
 
-    // Update isMobile on window resize
+    // Update isMobile on window resize (debounced)
     useEffect(() => {
-        const handleResize = () => setIsMobile(window.innerWidth < 768);
+        let timer;
+        const handleResize = () => {
+            clearTimeout(timer);
+            timer = setTimeout(() => setIsMobile(window.innerWidth < 768), 150);
+        };
         window.addEventListener("resize", handleResize);
-        return () => window.removeEventListener("resize", handleResize);
+        return () => {
+            clearTimeout(timer);
+            window.removeEventListener("resize", handleResize);
+        };
     }, []);
 
     /**

--- a/assets/js/Verse.js
+++ b/assets/js/Verse.js
@@ -1,11 +1,7 @@
-import React, { useRef, useState, useEffect, memo } from "react";
+import React, { useRef, useState, useEffect, useMemo, memo } from "react";
+import PropTypes from "prop-types";
 import { useIntl } from "react-intl";
-import {
-    loadNotes,
-    getVerseKey,
-    loadTranslationNotes,
-    getTranslationVerseKey,
-} from "./Notes";
+import { getVerseKey, getTranslationVerseKey } from "./Notes";
 
 const LONG_PRESS_DURATION = 500; // ms
 const NOTE_PREVIEW_TOGGLE_THRESHOLD = 80;
@@ -16,23 +12,55 @@ const Verse = memo(function Verse({
     chapterId,
     verseId,
     translationId,
-    onClick,
-    onLongPress,
-    onCompare,
+    translationName,
+    onVerseClick,
+    onVerseLongPress,
+    onVerseCompare,
     notesVersion = 0, // Increment to force note indicator refresh
     isHighlighted = false,
+    allNotes = {},
+    allTranslationNotes = {},
 }) {
     const { formatMessage } = useIntl();
-    const [hasNote, setHasNote] = useState(false);
-    const [noteText, setNoteText] = useState("");
-    const [hasTranslationNote, setHasTranslationNote] = useState(false);
-    const [translationNoteText, setTranslationNoteText] = useState("");
     const [isNoteExpanded, setIsNoteExpanded] = useState(false);
-    const [isPressing, setIsPressing] = useState(false);
+    const isPressing = useRef(false);
     const longPressTimer = useRef(null);
     const isLongPress = useRef(false);
     const startPos = useRef({ x: 0, y: 0 });
     const verseRef = useRef(null);
+
+    // Derive note state from pre-loaded notes (no localStorage reads)
+    const noteKey = getVerseKey(bookId, chapterId, verseId);
+    const noteText = useMemo(
+        () => (allNotes[noteKey] || "").trim(),
+        [allNotes, noteKey]
+    );
+    const hasNote = !!noteText;
+
+    const tKey = translationId
+        ? getTranslationVerseKey(translationId, bookId, chapterId, verseId)
+        : null;
+    const translationNoteText = useMemo(
+        () => (tKey ? (allTranslationNotes[tKey] || "").trim() : ""),
+        [allTranslationNotes, tKey]
+    );
+    const hasTranslationNote = !!translationNoteText;
+
+    // Reset expansion when verse changes
+    useEffect(() => {
+        setIsNoteExpanded(false);
+    }, [bookId, chapterId, verseId, notesVersion]);
+
+    const hasAnyNote = hasNote || hasTranslationNote;
+    const combinedNoteText = [noteText, translationNoteText]
+        .filter(Boolean)
+        .join("\n");
+
+    const isNoteExpandable =
+        (hasNote && (noteText.length > NOTE_PREVIEW_TOGGLE_THRESHOLD || noteText.includes("\n"))) ||
+        (hasTranslationNote && (translationNoteText.length > NOTE_PREVIEW_TOGGLE_THRESHOLD || translationNoteText.includes("\n")));
+
+    const appLink = `bib://${bookId}${chapterId}:${verseId}`;
 
     // Scroll into view when highlighted
     useEffect(() => {
@@ -44,69 +72,35 @@ const Verse = memo(function Verse({
         }
     }, [isHighlighted]);
 
-    // Check if this verse has a global note
-    useEffect(() => {
-        const notes = loadNotes();
-        const key = getVerseKey(bookId, chapterId, verseId);
-        const currentNote = (notes[key] || "").trim();
-        setHasNote(!!currentNote);
-        setNoteText(currentNote);
-        setIsNoteExpanded(false);
-    }, [bookId, chapterId, verseId, notesVersion]);
-
-    // Check if this verse has a translation-specific note
-    useEffect(() => {
-        if (!translationId) {
-            setHasTranslationNote(false);
-            setTranslationNoteText("");
-            return;
-        }
-        const tNotes = loadTranslationNotes();
-        const tKey = getTranslationVerseKey(
-            translationId,
-            bookId,
-            chapterId,
-            verseId
-        );
-        const tNote = (tNotes[tKey] || "").trim();
-        setHasTranslationNote(!!tNote);
-        setTranslationNoteText(tNote);
-    }, [bookId, chapterId, verseId, translationId, notesVersion]);
-
-    const hasAnyNote = hasNote || hasTranslationNote;
-    const combinedNoteText = [noteText, translationNoteText]
-        .filter(Boolean)
-        .join("\n");
-
-    const isNoteExpandable =
-        combinedNoteText.length > NOTE_PREVIEW_TOGGLE_THRESHOLD ||
-        combinedNoteText.includes("\n");
-
-    const appLink = `bib://${bookId}${chapterId}:${verseId}`;
-
     const openNoteEditor = (e) => {
         e.preventDefault();
         e.stopPropagation();
-        onLongPress?.(verseId);
+        onVerseLongPress?.(verseId);
     };
 
     const openComparison = (e) => {
         e.preventDefault();
         e.stopPropagation();
-        onCompare?.(verseId);
+        onVerseCompare?.(verseId);
+    };
+
+    // Helper: toggle pressing class directly on DOM (avoids React re-render)
+    const setPressingClass = (pressing) => {
+        isPressing.current = pressing;
+        verseRef.current?.classList.toggle("pressing", pressing);
     };
 
     // Trigger long press action
     const triggerLongPress = () => {
         isLongPress.current = true;
-        setIsPressing(false);
-        onLongPress?.(verseId);
+        setPressingClass(false);
+        onVerseLongPress?.(verseId);
     };
 
     // Touch events for mobile
     const handleTouchStart = (e) => {
         isLongPress.current = false;
-        setIsPressing(true);
+        setPressingClass(true);
         startPos.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
         longPressTimer.current = setTimeout(
             triggerLongPress,
@@ -115,7 +109,7 @@ const Verse = memo(function Verse({
     };
 
     const handleTouchEnd = (e) => {
-        setIsPressing(false);
+        setPressingClass(false);
         if (longPressTimer.current) {
             clearTimeout(longPressTimer.current);
             longPressTimer.current = null;
@@ -132,7 +126,7 @@ const Verse = memo(function Verse({
         const dx = Math.abs(touch.clientX - startPos.current.x);
         const dy = Math.abs(touch.clientY - startPos.current.y);
         if (dx > 10 || dy > 10) {
-            setIsPressing(false);
+            setPressingClass(false);
             if (longPressTimer.current) {
                 clearTimeout(longPressTimer.current);
                 longPressTimer.current = null;
@@ -146,7 +140,7 @@ const Verse = memo(function Verse({
         if (e.button !== 0) return;
 
         isLongPress.current = false;
-        setIsPressing(true);
+        setPressingClass(true);
         startPos.current = { x: e.clientX, y: e.clientY };
 
         longPressTimer.current = setTimeout(
@@ -155,29 +149,24 @@ const Verse = memo(function Verse({
         );
     };
 
-    const handleMouseUp = () => {
-        setIsPressing(false);
+    const cancelLongPress = () => {
+        setPressingClass(false);
         if (longPressTimer.current) {
             clearTimeout(longPressTimer.current);
             longPressTimer.current = null;
         }
     };
 
-    const handleMouseLeave = () => {
-        setIsPressing(false);
-        if (longPressTimer.current) {
-            clearTimeout(longPressTimer.current);
-            longPressTimer.current = null;
-        }
-    };
+    const handleMouseUp = cancelLongPress;
+    const handleMouseLeave = cancelLongPress;
 
     const handleMouseMove = (e) => {
         // Cancel long press if mouse moves more than 10px
-        if (!isPressing) return;
+        if (!isPressing.current) return;
         const dx = Math.abs(e.clientX - startPos.current.x);
         const dy = Math.abs(e.clientY - startPos.current.y);
         if (dx > 10 || dy > 10) {
-            setIsPressing(false);
+            setPressingClass(false);
             if (longPressTimer.current) {
                 clearTimeout(longPressTimer.current);
                 longPressTimer.current = null;
@@ -193,12 +182,12 @@ const Verse = memo(function Verse({
             e.stopPropagation();
             return;
         }
-        onClick?.(e);
+        onVerseClick?.(verseId);
     };
 
     // Prevent context menu on long press
     const handleContextMenu = (e) => {
-        if (isPressing || isLongPress.current) {
+        if (isPressing.current || isLongPress.current) {
             e.preventDefault();
         }
     };
@@ -215,17 +204,15 @@ const Verse = memo(function Verse({
     return (
         <div
             ref={verseRef}
-            className={`row line ${isPressing ? "pressing" : ""} ${
-                hasAnyNote ? "has-note" : ""
-            } ${isHighlighted ? "highlighted" : ""}`}
+            className={`row line ${hasAnyNote ? "has-note" : ""} ${isHighlighted ? "highlighted" : ""
+                }`}
         >
             <div className="col-2 col-lg-1 verse-number-cell">
                 <div className="verse-actions">
                     <button
                         type="button"
-                        className={`verse-action-btn verse-action-note ${
-                            hasAnyNote ? "has-note-value" : ""
-                        }`}
+                        className={`verse-action-btn verse-action-note ${hasAnyNote ? "has-note-value" : ""
+                            }`}
                         title={formatMessage({
                             id: hasAnyNote ? "edit" : "addNote",
                         })}
@@ -279,6 +266,13 @@ const Verse = memo(function Verse({
                 onMouseUp={handleMouseUp}
                 onMouseMove={handleMouseMove}
                 onMouseLeave={handleMouseLeave}
+                onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                        handleClick(e);
+                    }
+                }}
+                role="button"
+                tabIndex={0}
                 style={{ userSelect: "none" }}
             >
                 <div>{verseContent.replaceAll("//", "\u000A")}</div>
@@ -286,11 +280,10 @@ const Verse = memo(function Verse({
                     <div className="verse-note-preview-wrap">
                         {hasNote && (
                             <div
-                                className={`verse-note-preview ${
-                                    isNoteExpandable && !isNoteExpanded
-                                        ? "is-collapsed"
-                                        : ""
-                                }`}
+                                className={`verse-note-preview ${isNoteExpandable && !isNoteExpanded
+                                    ? "is-collapsed"
+                                    : ""
+                                    }`}
                             >
                                 {hasTranslationNote && (
                                     <span className="verse-note-label verse-note-label-global">
@@ -304,15 +297,14 @@ const Verse = memo(function Verse({
                         )}
                         {hasTranslationNote && (
                             <div
-                                className={`verse-note-preview verse-note-preview-translation ${
-                                    isNoteExpandable && !isNoteExpanded
-                                        ? "is-collapsed"
-                                        : ""
-                                }`}
+                                className={`verse-note-preview verse-note-preview-translation ${isNoteExpandable && !isNoteExpanded
+                                    ? "is-collapsed"
+                                    : ""
+                                    }`}
                             >
                                 {hasNote && (
                                     <span className="verse-note-label verse-note-label-translation">
-                                        {translationId}
+                                        {translationName || translationId}
                                     </span>
                                 )}
                                 {translationNoteText}
@@ -340,5 +332,23 @@ const Verse = memo(function Verse({
         </div>
     );
 });
+
+Verse.propTypes = {
+    verseContent: PropTypes.string.isRequired,
+    bookId: PropTypes.string.isRequired,
+    chapterId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired,
+    verseId: PropTypes.oneOfType([PropTypes.string, PropTypes.number])
+        .isRequired,
+    translationId: PropTypes.string,
+    translationName: PropTypes.string,
+    onVerseClick: PropTypes.func,
+    onVerseLongPress: PropTypes.func,
+    onVerseCompare: PropTypes.func,
+    notesVersion: PropTypes.number,
+    isHighlighted: PropTypes.bool,
+    allNotes: PropTypes.object,
+    allTranslationNotes: PropTypes.object,
+};
 
 export default Verse;

--- a/assets/js/useScrollDirection.js
+++ b/assets/js/useScrollDirection.js
@@ -3,6 +3,7 @@ import { useState, useEffect, useRef } from "react";
 /**
  * Custom hook to detect scroll direction and toggle visibility of navigation elements.
  * Returns true if navigation should be visible, false otherwise.
+ * Uses requestAnimationFrame throttle to avoid jank on mobile.
  *
  * @param {Object} options Configuration options
  * @param {number} options.threshold Minimum scroll difference to trigger change
@@ -11,41 +12,55 @@ import { useState, useEffect, useRef } from "react";
 const useScrollDirection = ({ threshold = 50, topThreshold = 10 } = {}) => {
     const [isVisible, setIsVisible] = useState(true);
     const prevScrollY = useRef(0);
+    const rafId = useRef(null);
 
     useEffect(() => {
         const handleScroll = () => {
-            const currentScrollY = window.scrollY;
+            // Throttle with requestAnimationFrame — at most one check per frame
+            if (rafId.current) return;
 
-            // Always show at the very top of the page
-            if (currentScrollY < topThreshold) {
-                setIsVisible(true);
+            rafId.current = requestAnimationFrame(() => {
+                rafId.current = null;
+
+                const currentScrollY = window.scrollY;
+
+                // Always show at the very top of the page
+                if (currentScrollY < topThreshold) {
+                    setIsVisible(true);
+                    prevScrollY.current = currentScrollY;
+                    return;
+                }
+
+                // Calculate difference
+                const diff = Math.abs(currentScrollY - prevScrollY.current);
+
+                // Ignore small scroll movements to prevent jitter
+                if (diff < threshold) {
+                    return;
+                }
+
+                // Determine direction
+                if (currentScrollY > prevScrollY.current) {
+                    // Scrolling down -> Hide
+                    setIsVisible(false);
+                } else {
+                    // Scrolling up -> Show
+                    setIsVisible(true);
+                }
+
                 prevScrollY.current = currentScrollY;
-                return;
-            }
-
-            // Calculate difference
-            const diff = Math.abs(currentScrollY - prevScrollY.current);
-
-            // Ignore small scroll movements to prevent jitter
-            if (diff < threshold) {
-                return;
-            }
-
-            // Determine direction
-            if (currentScrollY > prevScrollY.current) {
-                // Scrolling down -> Hide
-                setIsVisible(false);
-            } else {
-                // Scrolling up -> Show
-                setIsVisible(true);
-            }
-
-            prevScrollY.current = currentScrollY;
+            });
         };
 
         window.addEventListener("scroll", handleScroll, { passive: true });
 
-        return () => window.removeEventListener("scroll", handleScroll);
+        return () => {
+            window.removeEventListener("scroll", handleScroll);
+            if (rafId.current) {
+                cancelAnimationFrame(rafId.current);
+                rafId.current = null;
+            }
+        };
     }, [threshold, topThreshold]);
 
     return isVisible;

--- a/assets/js/useSwipeNavigation.js
+++ b/assets/js/useSwipeNavigation.js
@@ -11,6 +11,13 @@ const useSwipeNavigation = (
     onSwipeRight,
     { threshold = 50, enabled = true } = {}
 ) => {
+    // Store callbacks in refs so event listeners don't need to be re-attached
+    // when callbacks change (avoids listener churn on every render)
+    const onSwipeLeftRef = useRef(onSwipeLeft);
+    const onSwipeRightRef = useRef(onSwipeRight);
+    onSwipeLeftRef.current = onSwipeLeft;
+    onSwipeRightRef.current = onSwipeRight;
+
     const touchStartX = useRef(null);
     const touchStartY = useRef(null);
     const touchEndX = useRef(null);
@@ -50,10 +57,10 @@ const useSwipeNavigation = (
             ) {
                 if (deltaX > 0) {
                     // Swiped left - go to next chapter
-                    onSwipeLeft?.();
+                    onSwipeLeftRef.current?.();
                 } else {
                     // Swiped right - go to previous chapter
-                    onSwipeRight?.();
+                    onSwipeRightRef.current?.();
                 }
             }
 
@@ -80,7 +87,7 @@ const useSwipeNavigation = (
             document.removeEventListener("touchmove", handleTouchMove);
             document.removeEventListener("touchend", handleTouchEnd);
         };
-    }, [onSwipeLeft, onSwipeRight, threshold, enabled]);
+    }, [threshold, enabled]); // Callbacks removed from deps — stored in refs
 };
 
 export default useSwipeNavigation;

--- a/assets/js/useVersesCache.js
+++ b/assets/js/useVersesCache.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import { useRef, useCallback } from "react";
 import { safeJsonParse } from "./safeJsonParse";
 
@@ -146,8 +147,11 @@ const useVersesCache = (locale) => {
 };
 
 // Polyfill for requestIdleCallback (Safari)
-if (typeof window !== "undefined" && !window.requestIdleCallback) {
-    window.requestIdleCallback = (cb, options) => {
+if (
+    typeof globalThis !== "undefined" &&
+    typeof globalThis.requestIdleCallback !== "function"
+) {
+    globalThis.requestIdleCallback = (cb, options) => {
         const timeout = options?.timeout || 1000;
         return setTimeout(() => {
             cb({
@@ -156,7 +160,7 @@ if (typeof window !== "undefined" && !window.requestIdleCallback) {
             });
         }, Math.min(100, timeout));
     };
-    window.cancelIdleCallback = (id) => clearTimeout(id);
+    globalThis.cancelIdleCallback = (id) => clearTimeout(id);
 }
 
 export default useVersesCache;

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -320,7 +320,7 @@ main {
 }
 
 header,
-footer > .container {
+footer>.container {
   @include rb-border;
 }
 
@@ -432,13 +432,14 @@ footer {
   overflow-y: hidden;
   width: 100%;
 
-  & > .container {
+  &>.container {
     background: $rb-footer-background-color;
     padding-top: 0.2em;
     padding-bottom: 0.2em;
   }
 
   a {
+
     &:link,
     &:visited {
       color: $rb-footer-link-color;
@@ -465,8 +466,7 @@ footer {
     overflow: hidden;
     transform-origin: 46% 54%;
     animation: preloader-image-spin 1s linear infinite;
-    background: url("../images/preloader.svg") no-repeat scroll 0 0
-      rgba(0, 0, 0, 0);
+    background: url("../images/preloader.svg") no-repeat scroll 0 0 rgba(0, 0, 0, 0);
   }
 }
 
@@ -482,7 +482,13 @@ footer {
       padding-bottom: 0 !important;
     }
 
+    // Ensure selector row has vertical breathing room on mobile
+    &.pt-2 {
+      padding-top: 0.5rem !important;
+    }
+
     .row {
+      padding-top: 0.4rem;
       padding-left: 0.7em;
       padding-right: 0.7em;
 
@@ -500,7 +506,7 @@ footer {
   }
 
   header,
-  footer > .container,
+  footer>.container,
   main {
     @include rb-border-clean;
   }

--- a/assets/scss/_bottom-nav.scss
+++ b/assets/scss/_bottom-nav.scss
@@ -7,8 +7,8 @@
   bottom: 0;
   left: 0;
   right: 0;
-  display: flex;
-  justify-content: space-around;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
   align-items: center;
   @include glassmorphism-panel(0.9, 12px);
   border-top: 1px solid rgba(0, 0, 0, 0.05); // Subtler border
@@ -32,13 +32,12 @@
   align-items: center;
   justify-content: center;
   gap: 0.25rem;
-  padding: 0.5rem 1rem;
+  padding: 0.5rem 0.5rem;
   background: transparent;
   border: none;
   color: #555;
   cursor: pointer;
-  cursor: pointer;
-  min-width: 70px;
+  width: 100%;
   border-radius: 12px;
   @include interactive-scale(0.92);
 

--- a/assets/scss/_notes.scss
+++ b/assets/scss/_notes.scss
@@ -285,7 +285,7 @@
 
   &.note-action-delete:hover {
     background: rgba(220, 53, 69, 0.1);
-    color: #dc3545;
+    color: #c82333;
   }
 
   @include dark-mode {
@@ -702,7 +702,7 @@
   }
 
   &:hover {
-    color: #555;
+    color: #333;
     background: rgba(0, 0, 0, 0.02);
   }
 
@@ -716,7 +716,7 @@
     color: #999;
 
     &:hover {
-      color: #ccc;
+      color: #fff;
       background: rgba(255, 255, 255, 0.03);
     }
 
@@ -759,11 +759,11 @@
 
 .note-type-global {
   background: rgba(108, 117, 125, 0.12);
-  color: #6c757d;
+  color: #495057;
 
   @include dark-mode {
     background: rgba(108, 117, 125, 0.25);
-    color: #adb5bd;
+    color: #f8f9fa;
   }
 }
 
@@ -843,21 +843,21 @@
 
 .notes-import-success {
   background: rgba(40, 167, 69, 0.1);
-  color: #28a745;
+  color: #1e7e34;
 
   @include dark-mode {
     background: rgba(40, 167, 69, 0.2);
-    color: #4caf50;
+    color: #81c784;
   }
 }
 
 .notes-import-error {
   background: rgba(220, 53, 69, 0.1);
-  color: #dc3545;
+  color: #c82333;
 
   @include dark-mode {
     background: rgba(220, 53, 69, 0.2);
-    color: #ef5350;
+    color: #ffcdd2;
   }
 }
 
@@ -879,11 +879,11 @@
 
 .verse-note-label-global {
   background: rgba(108, 117, 125, 0.15);
-  color: #6c757d;
+  color: #495057;
 
   @include dark-mode {
     background: rgba(108, 117, 125, 0.3);
-    color: #adb5bd;
+    color: #f8f9fa;
   }
 }
 

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -126,6 +126,7 @@
   "suggestionBook": "Buch",
   "suggestionPhrase": "Beliebt",
   "chapterComparison": "Kapitelvergleich",
+  "chapterComparisonShort": "Vergleich",
   "chapterCompSelectTranslation": "Übersetzung wählen...",
   "chapterCompSelectHint": "Wählen Sie Übersetzungen zum Vergleichen aus den Dropdown-Listen oben.",
   "chapterCompError": "Kapitel konnte nicht geladen werden.",

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -126,6 +126,7 @@
   "suggestionBook": "book",
   "suggestionPhrase": "popular",
   "chapterComparison": "Chapter Comparison",
+  "chapterComparisonShort": "Compare",
   "chapterCompSelectTranslation": "Select translation...",
   "chapterCompSelectHint": "Select translations to compare from the dropdowns above.",
   "chapterCompError": "Failed to load chapter.",

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -126,6 +126,7 @@
   "suggestionBook": "księga",
   "suggestionPhrase": "popularne",
   "chapterComparison": "Porównanie rozdziałów",
+  "chapterComparisonShort": "Porównaj",
   "chapterCompSelectTranslation": "Wybierz tłumaczenie...",
   "chapterCompSelectHint": "Wybierz tłumaczenia do porównania z list rozwijanych powyżej.",
   "chapterCompError": "Nie udało się załadować rozdziału.",

--- a/tests/js/navigation.test.js
+++ b/tests/js/navigation.test.js
@@ -208,7 +208,7 @@ function testRaceConditionScenario() {
   };
 
   let selectedBook = "gen";
-  let selectedChapter = 5;
+
   const apiCalls = [];
 
   // Simulated fixed changeSelectedChapter with bookOverride
@@ -226,7 +226,6 @@ function testRaceConditionScenario() {
 
   // Fixed: navigateToBookAndChapter passes book override
   const navigateToBookAndChapter = (book, chapter) => {
-    selectedChapter = chapter;
     selectedBook = book;
     changeSelectedChapter(chapter, book);
   };
@@ -249,7 +248,6 @@ function testRaceConditionWithSameBook() {
   // When the user selects a different chapter in the SAME book,
   // navigateToBookAndChapter should still work correctly
   let selectedBook = "gen";
-  let selectedChapter = 3;
   const apiCalls = [];
 
   const changeSelectedChapter = (chapter, bookOverride) => {
@@ -258,7 +256,6 @@ function testRaceConditionWithSameBook() {
   };
 
   const navigateToBookAndChapter = (book, chapter) => {
-    selectedChapter = chapter;
     selectedBook = book;
     changeSelectedChapter(chapter, book);
   };
@@ -268,7 +265,6 @@ function testRaceConditionWithSameBook() {
   console.assert(apiCalls[0].book === "gen", "Should use gen");
   console.assert(apiCalls[0].chapter === 10, "Should use chapter 10");
   console.assert(selectedBook === "gen", "Book should remain gen");
-  console.assert(selectedChapter === 10, "Chapter should be 10");
 
   console.log("✓ Race condition with same book: works correctly");
 }
@@ -502,6 +498,6 @@ if (typeof module !== "undefined" && module.exports) {
 }
 
 // Auto-run in browser
-if (typeof window !== "undefined") {
+if (typeof globalThis.window !== "undefined") {
   runAllTests();
 }

--- a/tests/js/notes.test.js
+++ b/tests/js/notes.test.js
@@ -52,7 +52,7 @@ function testGetTranslationVerseKey() {
   );
   console.assert(
     getTranslationVerseKey("pl_pns_2018", "1co", 13, 4) ===
-    "pl_pns_2018:1co_13_4",
+      "pl_pns_2018:1co_13_4",
     "getTranslationVerseKey should handle complex translation IDs"
   );
   console.log("✓ getTranslationVerseKey tests passed");
@@ -188,10 +188,7 @@ function testTranslationNotes() {
     loaded["pl_pns_2018:gen_4_6"] === "Notatka PNŚ 2018",
     "Should load second translation note"
   );
-  console.assert(
-    Object.keys(loaded).length === 2,
-    "Should have correct count"
-  );
+  console.assert(Object.keys(loaded).length === 2, "Should have correct count");
 
   console.log("✓ Translation notes storage tests passed");
 }
@@ -253,11 +250,11 @@ function testNotesImportMerge() {
 function testXmlEscaping() {
   const escapeXml = (str) =>
     str
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&apos;");
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&apos;");
 
   console.assert(
     escapeXml("Hello & World") === "Hello &amp; World",
@@ -286,11 +283,11 @@ function testXmlEscaping() {
 function testXmlExportStructure() {
   const escapeXml = (str) =>
     str
-      .replace(/&/g, "&amp;")
-      .replace(/</g, "&lt;")
-      .replace(/>/g, "&gt;")
-      .replace(/"/g, "&quot;")
-      .replace(/'/g, "&apos;");
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&apos;");
 
   const globalNotes = { gen_4_7: "Global note" };
   const translationNotes = {
@@ -305,7 +302,9 @@ function testXmlExportStructure() {
   xml += "  <translation>\n";
   for (const [key, text] of Object.entries(globalNotes)) {
     const [book, chapter, verse] = key.split("_");
-    xml += `    <note book="${book}" chapter="${chapter}" verse="${verse}">${escapeXml(text)}</note>\n`;
+    xml += `    <note book="${book}" chapter="${chapter}" verse="${verse}">${escapeXml(
+      text
+    )}</note>\n`;
   }
   xml += "  </translation>\n";
 
@@ -321,7 +320,9 @@ function testXmlExportStructure() {
   for (const [translationId, notes] of Object.entries(byTranslation)) {
     xml += `  <translation id="${escapeXml(translationId)}">\n`;
     for (const { book, chapter, verse, text } of notes) {
-      xml += `    <note book="${book}" chapter="${chapter}" verse="${verse}">${escapeXml(text)}</note>\n`;
+      xml += `    <note book="${book}" chapter="${chapter}" verse="${verse}">${escapeXml(
+        text
+      )}</note>\n`;
     }
     xml += "  </translation>\n";
   }
@@ -455,6 +456,6 @@ if (typeof module !== "undefined" && module.exports) {
 }
 
 // Auto-run in browser
-if (typeof window !== "undefined") {
+if (typeof globalThis.window !== "undefined") {
   runAllTests();
 }

--- a/tests/js/verse.test.js
+++ b/tests/js/verse.test.js
@@ -54,46 +54,75 @@ function testAppLinkFormat() {
 function testNotePreviewThreshold() {
   const NOTE_PREVIEW_TOGGLE_THRESHOLD = 80;
 
-  const isNoteExpandable = (noteText) =>
-    noteText.length > NOTE_PREVIEW_TOGGLE_THRESHOLD || noteText.includes("\n");
+  // New logic: checks each note text individually
+  const isNoteExpandable = (noteText, translationNoteText) => {
+    const hasNote = !!noteText;
+    const hasTranslationNote = !!translationNoteText;
+    return (
+      (hasNote &&
+        (noteText.length > NOTE_PREVIEW_TOGGLE_THRESHOLD ||
+          noteText.includes("\n"))) ||
+      (hasTranslationNote &&
+        (translationNoteText.length > NOTE_PREVIEW_TOGGLE_THRESHOLD ||
+          translationNoteText.includes("\n")))
+    );
+  };
 
-  // Short note — not expandable
+  // Short single note — not expandable
   console.assert(
-    isNoteExpandable("Short note") === false,
-    "Short note should NOT be expandable"
+    isNoteExpandable("Short note", "") === false,
+    "Short single note should NOT be expandable"
   );
 
   // Exactly at threshold — not expandable
   const exactText = "a".repeat(80);
   console.assert(
-    isNoteExpandable(exactText) === false,
+    isNoteExpandable(exactText, "") === false,
     "Note at exactly 80 chars should NOT be expandable"
   );
 
   // One char over threshold — expandable
   const overText = "a".repeat(81);
   console.assert(
-    isNoteExpandable(overText) === true,
+    isNoteExpandable(overText, "") === true,
     "Note at 81 chars should be expandable"
   );
 
   // Long note — expandable
   const longNote = "a".repeat(200);
   console.assert(
-    isNoteExpandable(longNote) === true,
+    isNoteExpandable(longNote, "") === true,
     "Long note (200 chars) should be expandable"
   );
 
-  // Multi-line note (short but has newline) — expandable
+  // Multi-line single note — expandable
   console.assert(
-    isNoteExpandable("Line 1\nLine 2") === true,
+    isNoteExpandable("Line 1\nLine 2", "") === true,
     "Multi-line note should be expandable regardless of length"
   );
 
   // Empty note — not expandable
   console.assert(
-    isNoteExpandable("") === false,
+    isNoteExpandable("", "") === false,
     "Empty note should NOT be expandable"
+  );
+
+  // Two short notes together — NOT expandable (separator \n should not trigger)
+  console.assert(
+    isNoteExpandable("Amen", "notatka dla tłumaczenia") === false,
+    "Two short notes combined should NOT be expandable (separator \\n fix)"
+  );
+
+  // Short global + long translation — expandable (translation is long)
+  console.assert(
+    isNoteExpandable("Amen", "a".repeat(81)) === true,
+    "Short global + long translation note should be expandable"
+  );
+
+  // Short global + multiline translation — expandable
+  console.assert(
+    isNoteExpandable("Amen", "Line 1\nLine 2") === true,
+    "Short global + multiline translation note should be expandable"
   );
 
   console.log("✓ Note preview threshold tests passed");


### PR DESCRIPTION
## Summary of changes

### 1. Mobile header selector spacing
- Added padding-top to the first header row on viewports < 575px so the TranslationSelector has breathing room matching the verse row margin.

### 2. Swapped Search ↔ Chapter Comparison on mobile
- **Header (Navigator.js)**: The mobile action button now opens **Search** (was Chapter Comparison)
- **Bottom Navigation**: Chapter Comparison button replaces the old Search button
- **CSS fix**: Bottom nav layout changed from lex + justify-content: space-around to **CSS Grid with 5 equal columns** (epeat(5, 1fr)) — center button is now always geometrically centered regardless of label lengths

### 3. Full translation name in notes (instead of ID)
- NotesPanel now receives a 	ranslations prop from Bible.js and resolves 	ranslationId → human-readable name (e.g. _Biblia Gdańska_ instead of _PL_BG_)
- Verse.js note-preview label also shows the full name via new 	ranslationName prop chained through Reader.js

### 4. Fix: hide More/Less toggle when not needed
- The previous logic concatenated global + translation note text with \n, so the separator itself triggered isNoteExpandable = true for short combined notes.
- **Fix**: each note text is now checked individually — the toggle button only appears when a single note actually needs truncation.

### 5. Book sigla in bottom nav center button
- Center button shows **abbreviated book name + chapter** (e.g. _Rdz 4_) using the existing getSigla() with intl.locale, instead of the full book name that caused layout shifts.

### 6. Short label: chapterComparisonShort
- Added chapterComparisonShort translation key (PL: _Porównaj_, EN: _Compare_, DE: _Vergleich_) used in the BottomNavigation label.

### Tests
- 	ests/js/verse.test.js — updated 	estNotePreviewThreshold to reflect the new two-argument isNoteExpandable logic and added edge cases covering the bug fix.