### PR TITLE
Perf: Optimize mobile fullscreen overlays rendering

### DIFF
--- a/assets/js/Bible.js
+++ b/assets/js/Bible.js
@@ -598,6 +598,15 @@ const Bible = ({ intl, setLocale }) => {
         [navigateToBookAndChapter]
     );
 
+    // Toggle body class when fullscreen overlays are open to hide background content and improve performance
+    useEffect(() => {
+        if (isSelectionOpen || comparedVerse || isChapterCompOpen) {
+            document.body.classList.add("has-fullscreen-overlay");
+        } else {
+            document.body.classList.remove("has-fullscreen-overlay");
+        }
+    }, [isSelectionOpen, comparedVerse, isChapterCompOpen]);
+
     // Render content
     if (error) {
         return (

--- a/assets/scss/_comparison-modal.scss
+++ b/assets/scss/_comparison-modal.scss
@@ -4,8 +4,18 @@
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
 
+  @media (max-width: 991.98px) {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: #ffffff;
+  }
+
   @include dark-mode {
     background: rgba(18, 18, 18, 0.85);
+
+    @media (max-width: 991.98px) {
+      background: #121212;
+    }
   }
 
   .selection-content {
@@ -66,11 +76,12 @@
     margin-right: -1rem;
     padding-left: 1rem;
     padding-right: 1rem;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+    will-change: transform; // Hint for browser during scroll
 
     @include dark-mode {
       background: rgba(30, 30, 30, 0.97);
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+      border-bottom-color: rgba(255, 255, 255, 0.1);
     }
   }
 }
@@ -90,6 +101,8 @@
 
 .comparison-box-secondary {
   border: 1px solid rgba(0, 0, 0, 0.1);
+  content-visibility: auto;
+  contain-intrinsic-size: auto 150px;
 
   @include dark-mode {
     border-color: rgba(255, 255, 255, 0.1);

--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -447,6 +447,13 @@ header.sticky-top {
   background: rgba(255, 255, 255, 0.95);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
+
+  @media (max-width: 991.98px) {
+    backdrop-filter: none;
+    -webkit-backdrop-filter: none;
+    background: #ffffff;
+  }
+
   display: flex;
   align-items: stretch;
   justify-content: center;
@@ -454,6 +461,10 @@ header.sticky-top {
 
   @include dark-mode {
     background: var(--dm-bg-overlay);
+
+    @media (max-width: 991.98px) {
+      background: var(--dm-bg-surface, #121212);
+    }
   }
 }
 
@@ -731,6 +742,9 @@ header.sticky-top {
 }
 
 .chapter-comp-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 60px;
+
   &:nth-child(even) {
     background: rgba(0, 0, 0, 0.015);
 
@@ -799,6 +813,8 @@ header.sticky-top {
   gap: 0.5rem;
   padding: 0.55rem 1rem;
   border-bottom: 1px solid #f0f0f0;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 80px;
 
   @include dark-mode {
     border-bottom-color: #2a2a2a;
@@ -858,4 +874,19 @@ select:focus-visible,
 textarea:focus-visible {
   outline: none;
   @include focus-ring;
+}
+
+// 11. Fullscreen Overlay Performance Optimization
+// ---------------------------------------------------------
+body.has-fullscreen-overlay {
+  overflow: hidden;
+
+  // Hide the main application content to save GPU/CPU cycles
+  main,
+  header.sticky-top,
+  .bottom-nav {
+    content-visibility: hidden;
+    opacity: 0;
+    pointer-events: none;
+  }
 }

--- a/assets/scss/_selection-grid.scss
+++ b/assets/scss/_selection-grid.scss
@@ -63,6 +63,8 @@
   -webkit-appearance: none;
   touch-action: manipulation;
   -webkit-tap-highlight-color: transparent;
+  content-visibility: auto;
+  contain-intrinsic-size: auto 54px;
 
   &:hover {
     transform: translateY(-3px);

--- a/docs/mobile-fullscreen-vs-drawer-review-2026-03-10.md
+++ b/docs/mobile-fullscreen-vs-drawer-review-2026-03-10.md
@@ -1,0 +1,292 @@
+# Mobile Performance Review: Fullscreen vs Drawer UI
+
+Data: 2026-03-10
+
+Zakres:
+- statyczny code review
+- analiza wspolnych cech dwoch grup interfejsu
+- fokus na problemy wydajnosciowe na slabszych smartfonach
+
+## Cel
+
+Zidentyfikowac wspolny mianownik dla dwoch grup funkcji:
+
+Grupa A:
+- SideMenu opcji
+- menu notatek
+- wyszukiwanie
+
+Grupa B:
+- porownywarka wersetow
+- porownywarka rozdzialow
+- menu wyboru ksiag
+
+Oraz odpowiedziec, dlaczego grupa B na niektorych urzadzeniach:
+- nie dziala poprawnie
+- albo powoduje bardzo mocne spowolnienie responsywnosci
+
+podczas gdy grupa A:
+- miewa przyciecia
+- ale zwykle pozostaje uzywalna nawet na slabszych telefonach
+
+## Wniosek glowny
+
+Roznica nie sprowadza sie tylko do tego, ze jedna grupa otwiera sie jako okienko, a druga pelnoekranowo.
+
+Rzeczywisty podzial jest taki:
+
+- Grupa A to panele typu drawer
+- Grupa B to pelnoekranowe workspace overlaye
+
+To sa dwa rozne wzorce UI, ktore maja bardzo rozny koszt renderowania, compositingu i obslugi scrolla na mobile.
+
+## Grupa A: drawer / panel boczny
+
+Do tej grupy naleza:
+- SideMenu
+- Notes
+- Search
+
+### Wspolne cechy
+
+- ograniczona szerokosc
+- panel osadzony przy prawej krawedzi
+- wejscie przez `transform: translateX(...)`
+- osobny scroll wewnatrz panelu
+- glowna tresc aplikacji pozostaje w tle
+- panel nie zajmuje calego viewportu
+
+### Potwierdzenie w kodzie
+
+- [assets/scss/_side-menu.scss](/d:/rbiblia-web/assets/scss/_side-menu.scss#L78)
+- [assets/scss/_notes.scss](/d:/rbiblia-web/assets/scss/_notes.scss#L26)
+- [assets/scss/_search.scss](/d:/rbiblia-web/assets/scss/_search.scss#L26)
+- [assets/scss/_mobile.scss](/d:/rbiblia-web/assets/scss/_mobile.scss#L59)
+
+### Znaczenie wydajnosciowe
+
+Ta grupa jest relatywnie lzejsza, bo:
+- repaint i compositing obejmuja mniejszy obszar ekranu
+- panel zwykle ma mniejszy DOM niz widok full screen
+- mniejsza jest liczba elementow renderowanych jednoczesnie
+- animacja wejscia jest prostsza i lokalna
+
+### Dlaczego mimo to bywaja przyciecia
+
+Sa nadal obecne koszty:
+- `backdrop-filter`
+- `box-shadow`
+- `position: fixed`
+- `will-change`
+- osobny scroll i animowane wejscie panelu
+
+Pliki:
+- [assets/scss/_mixins.scss](/d:/rbiblia-web/assets/scss/_mixins.scss#L3)
+- [assets/scss/_mixins.scss](/d:/rbiblia-web/assets/scss/_mixins.scss#L10)
+- [assets/scss/_notes.scss](/d:/rbiblia-web/assets/scss/_notes.scss#L5)
+- [assets/scss/_search.scss](/d:/rbiblia-web/assets/scss/_search.scss#L5)
+
+W praktyce:
+- slab­sze telefony to odczuwaja
+- ale zwykle jeszcze nie przekracza to progu calkowitej nieuzywalnosci
+
+## Grupa B: fullscreen workspace overlay
+
+Do tej grupy naleza:
+- SelectionGrid
+- ComparisonGrid
+- ChapterComparison
+
+### Wspolne cechy
+
+- zajmuja caly viewport
+- sa nakladane jako pelnoekranowa warstwa nad aplikacja
+- maja wlasny duzy kontener layoutu i scrolla
+- renderuja duzo tresci naraz
+- czesto utrzymuja aktywne tlo aplikacji pod spodem
+- korzystaja z overlay/background blur na calym ekranie
+
+### Potwierdzenie w kodzie
+
+- [assets/js/SelectionGrid.js](/d:/rbiblia-web/assets/js/SelectionGrid.js#L99)
+- [assets/js/ComparisonGrid.js](/d:/rbiblia-web/assets/js/ComparisonGrid.js#L583)
+- [assets/js/ChapterComparison.js](/d:/rbiblia-web/assets/js/ChapterComparison.js#L208)
+- [assets/scss/_selection-grid.scss](/d:/rbiblia-web/assets/scss/_selection-grid.scss#L5)
+- [assets/scss/_comparison-modal.scss](/d:/rbiblia-web/assets/scss/_comparison-modal.scss#L2)
+- [assets/scss/_mobile.scss](/d:/rbiblia-web/assets/scss/_mobile.scss#L443)
+
+### Wspolny mianownik architektoniczny
+
+To nie sa zwykle modale.
+
+To sa pelnoekranowe powierzchnie robocze, ktore:
+- przykrywaja cala aplikacje
+- same potrafia byc ciezkie
+- jednoczesnie nie odpinaja w praktyce glownych komponentow znajdujacych sie pod spodem
+
+W `Bible` reader pozostaje zamontowany niezaleznie od otwarcia tych widokow:
+- [assets/js/Bible.js](/d:/rbiblia-web/assets/js/Bible.js#L646)
+- [assets/js/Bible.js](/d:/rbiblia-web/assets/js/Bible.js#L670)
+
+To oznacza, ze urzadzenie utrzymuje naraz:
+- glowny reader
+- pelnoekranowy overlay
+- dodatkowy duzy DOM overlayu
+- warstwy compositingu i blur
+
+## Dlaczego fullscreen powoduje duzo gorsze lagi
+
+### 1. Blur i compositing obejmuja caly ekran
+
+Najwazniejsza wspolna cecha problematyczna dla tej grupy:
+- `backdrop-filter` na warstwie pelnoekranowej
+
+Pliki:
+- [assets/scss/_selection-grid.scss](/d:/rbiblia-web/assets/scss/_selection-grid.scss#L11)
+- [assets/scss/_comparison-modal.scss](/d:/rbiblia-web/assets/scss/_comparison-modal.scss#L4)
+- [assets/scss/_mobile.scss](/d:/rbiblia-web/assets/scss/_mobile.scss#L447)
+
+Skutek:
+- GPU musi przetwarzac caly viewport
+- koszt rośnie przy scrollu i animacji
+- slabsze urzadzenia Android bardzo zle znosza ten wzorzec
+
+### 2. Overlaye buduja duzy DOM
+
+`SelectionGrid`:
+- renderuje wiele sekcji i wiele kafelkow ksiag/rozdzialow
+- [assets/js/SelectionGrid.js](/d:/rbiblia-web/assets/js/SelectionGrid.js#L127)
+
+`ComparisonGrid`:
+- renderuje panel glowny, sticky area, wiele slotow porownania i teksty porownawcze
+- [assets/js/ComparisonGrid.js](/d:/rbiblia-web/assets/js/ComparisonGrid.js#L602)
+- [assets/js/ComparisonGrid.js](/d:/rbiblia-web/assets/js/ComparisonGrid.js#L724)
+
+`ChapterComparison`:
+- renderuje caly rozdzial w ukladzie desktopowym lub mobilnym
+- [assets/js/ChapterComparison.js](/d:/rbiblia-web/assets/js/ChapterComparison.js#L331)
+- [assets/js/ChapterComparison.js](/d:/rbiblia-web/assets/js/ChapterComparison.js#L355)
+
+Skutek:
+- duzy koszt layoutu
+- duzy koszt paintu
+- wzrost zapotrzebowania na pamiec
+
+### 3. Tlo pozostaje aktywne
+
+Fullscreen overlay nie zastępuje aplikacji, tylko naklada sie na nia.
+
+W praktyce nadal istnieje:
+- Reader z wersetami
+- BottomNavigation
+- dodatkowe stany i event handling aplikacji glownej
+
+Plik:
+- [assets/js/Bible.js](/d:/rbiblia-web/assets/js/Bible.js#L616)
+
+Skutek:
+- uklad nie jest minimalny
+- koszty tła nie znikaja
+- przy slabszym sprzecie system dochodzi szybciej do limitu wydajnosci
+
+### 4. W porownywarkach dochodzi koszt danych i CPU
+
+`ComparisonGrid`:
+- pobiera caly rozdzial dla kazdej translacji, mimo ze pokazuje pojedynczy werset
+- liczy diffy tekstu i LCS
+
+Pliki:
+- [assets/js/ComparisonGrid.js](/d:/rbiblia-web/assets/js/ComparisonGrid.js#L189)
+- [assets/js/ComparisonGrid.js](/d:/rbiblia-web/assets/js/ComparisonGrid.js#L333)
+- [assets/js/ComparisonGrid.js](/d:/rbiblia-web/assets/js/ComparisonGrid.js#L372)
+
+`ChapterComparison`:
+- pobiera dwa cale rozdzialy i renderuje ich sume
+
+Plik:
+- [assets/js/ChapterComparison.js](/d:/rbiblia-web/assets/js/ChapterComparison.js#L89)
+
+Skutek:
+- spowolnienie nie jest tylko wizualne
+- to takze obciazenie CPU i parsowania danych
+
+### 5. Sticky i nested scroll podnosza koszt na mobile
+
+W `ComparisonGrid` jest sticky pinned area:
+- [assets/scss/_comparison-modal.scss](/d:/rbiblia-web/assets/scss/_comparison-modal.scss#L58)
+
+W `ChapterComparison` jest osobny przewijany body:
+- [assets/scss/_mobile.scss](/d:/rbiblia-web/assets/scss/_mobile.scss#L652)
+
+Skutek:
+- dodatkowe przeliczenia layoutu podczas przewijania
+- wieksze ryzyko lagow na slabszych Androidach
+
+## Dlaczego grupa A dziala, a grupa B juz nie
+
+Najkrotsza odpowiedz:
+
+Grupa A obciaza tylko fragment ekranu.
+
+Grupa B obciaza:
+- caly ekran
+- caly compositing viewportu
+- duzy DOM overlayu
+- aktywne tlo aplikacji
+- czasem dodatkowo siec i CPU
+
+To jest wspolny mianownik, ktory najlepiej tlumaczy:
+- przyciecia w drawerach
+- ale znacznie gorsze lagi lub calkowita nieuzywalnosc fullscreen view
+
+## Najbardziej prawdopodobny root cause
+
+Najbardziej prawdopodobny problem nie jest w pojedynczej funkcji fullscreen API.
+
+Najbardziej prawdopodobny root cause to wzorzec architektoniczny:
+- pelnoekranowy overlay
+- z blur na calym viewportcie
+- z duza iloscia renderowanej tresci
+- przy pozostawieniu aktywnej aplikacji pod spodem
+
+Na slabszych smartfonach ten wzorzec przekracza budzet wydajnosci i daje:
+- opoznienia dotyku
+- jank przy scrollu
+- zawieszanie po otwarciu widoku
+- w skrajnych przypadkach wrazenie, ze funkcja "nie dziala"
+
+## Ktore elementy sa najbardziej podejrzane
+
+Najbardziej ryzykowne dla mobile sa:
+- pelnoekranowe `backdrop-filter`
+- duze pelnoekranowe kontenery `fixed`
+- sticky header w `ComparisonGrid`
+- renderowanie wielu translacji naraz
+- renderowanie calego rozdzialu w `ChapterComparison`
+- utrzymywanie aktywnego readera pod fullscreen overlayem
+
+## Podsumowanie
+
+Wspolny mianownik grupy A:
+- drawer / side panel
+- mniejszy obszar repaintu
+- mniejszy koszt DOM
+- mniejszy koszt compositingu
+
+Wspolny mianownik grupy B:
+- pelnoekranowy workspace overlay
+- blur i compositing na calym ekranie
+- duzy DOM
+- aktywne tlo aplikacji pod spodem
+- w czesci przypadkow dodatkowy koszt sieci i CPU
+
+To jest najtrafniejsze wyjasnienie, dlaczego fullscreenowe funkcje na niektorych urzadzeniach niedzialaja lub dramatycznie psuja responsywnosc, a panele typu SideMenu/Notes/Search tylko czasem przycinaja.
+
+## Metoda
+
+Raport przygotowany na podstawie statycznego przegladu kodu:
+- bez zmian w kodzie
+- bez runtime profilingu
+- bez testow na fizycznych urzadzeniach
+
+Wnioski wynikaja z architektury UI, sposobu renderowania, stylow CSS oraz wzorcow znanych z problemow wydajnosciowych na slabszych telefonach z Androidem.


### PR DESCRIPTION
## Cel PR-a
Rozwiązanie problemów wydajnościowych z panelami zajmującymi pełen ekran (tzw. Grupa B - np. okno porówywania wersetów czy wyboru ksiąg), które drastycznie spowalniały bądź całkowicie zacinały aplikację na słabszych urządzeniach z systemem Android.

Rozwiązanie bazuje na raporcie *docs/mobile-fullscreen-vs-drawer-review-2026-03-10.md*.

## Co zostało zmienione
1. **Odtworzono poprawne obiekty Overlay na mobile (Bez Blura)**
   Całkowicie deaktywowano \ackdrop-filter\ w plikach \_comparison-modal.scss\ oraz użytych zmiennych domyślnych dla modali poniżej 991px szerokości, na rzecz jednolitego koloru.

2. **Wstrzymanie Render Tree dla głownego readera w tle**
   Dodano stan sprawdzający wyświetlane Modale. Gdy okno Grupy B jest otwarte, znacznik \<body>\ dostaje flagę \has-fullscreen-overlay\, która modyfikuje tag \<main>\ i nawigację z użyciem \content-visibility: hidden; opacity: 0; pointer-events: none\. Radykalnie odciąża to procesor (szczególnie w Readerze nasłuchującym tony click eventów i swipe'ów po węzłach tekstu).

3. **Windowing / Virtualizacja obszarów za pomocą content-visibility**
   Dla paneli renderujących olbrzymie bloki DOM (np. *SelectionGrid* listujący wszystkie księgi / *ComparisonGrid* z węzłami wersetów) wdrożono \content-visibility: auto\ wraz z szacunkami \contain-intrinsic-size\ co informuje silnik Webkit/Gecko by wyłączał z farby kafelki pozostające poza scrollbarem. Przemnożenie oszczędności działa na dziesiątki węzłów.

4. **Odpięte malowanie headerów przy \sticky\.**
   Przepisano logikę animowaną/przyklejaną pod klasą \.comparison-pinned-area\. Usunieto \ox-shadow\ wyrzucając obliczanie cienia w obiekcie, implementując proste \order-bottom\. Dano dyrektywę kompilatora \will-change: transform\ co zmusza do tworzenia osobnego kafelka dla GPU na mobile zapobiegając stuteterom.

Powinno to całkowicie pożegnać freezy na najsłabszych low-endowych telefonach. Testowane metodą kompilacji WebPack.

### Kroki przetestowania:
- Otworzyć widok na smartfonie z wolnym CPU (w stymulacji Performance Tab z procesorem 4x - 6x Slowdown).
- Kliknac otworzenie okna porownywania \ChapterComparison\ lub \SelectionGrid\ wybierajac księgę.