### PR TITLE
fix(mobile): resolve blank screen on fullscreen overlays and fix note editor positioning

### DIFF
--- a/assets/scss/_mixins.scss
+++ b/assets/scss/_mixins.scss
@@ -137,24 +137,33 @@
 
 @mixin premium-modal($max-width: 500px) {
   position: fixed;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -45%) scale(0.95);
+  inset: 0;
+  margin: auto;
   width: 90%;
   max-width: $max-width;
+  height: fit-content;
+  max-height: calc(100vh - 2rem);
+  box-sizing: border-box;
   @include glassmorphism-panel(0.9, 30px);
   z-index: 3000;
   border-radius: 28px;
-  padding: 2.2rem;
+  display: flex;
+  flex-direction: column;
   opacity: 0;
   visibility: hidden;
-  transition: all 0.4s cubic-bezier(0.16, 1, 0.3, 1);
+  transition: opacity 0.3s ease, visibility 0.3s ease;
   box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+
+  // On small mobile screens, use full width with safe margins
+  @media (max-width: 480px) {
+    width: calc(100% - 1.5rem);
+    max-width: none;
+    border-radius: 20px;
+  }
 
   &.open {
     opacity: 1;
     visibility: visible;
-    transform: translate(-50%, -50%) scale(1);
   }
 
   @include dark-mode {

--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -510,6 +510,11 @@ header.sticky-top {
   font-weight: 600;
   margin: 0;
   font-family: $font-ui;
+  color: #333;
+
+  @include dark-mode {
+    color: var(--dm-text-primary, #f0f0f0);
+  }
 }
 
 .chapter-comp-close {
@@ -562,6 +567,7 @@ header.sticky-top {
 
   @include dark-mode {
     border-color: #333;
+    color: var(--dm-text-primary, #f0f0f0);
   }
 }
 
@@ -878,15 +884,26 @@ textarea:focus-visible {
 
 // 11. Fullscreen Overlay Performance Optimization
 // ---------------------------------------------------------
+// When a fullscreen overlay (SelectionGrid, ComparisonGrid, ChapterComparison)
+// is open, hide background content to reduce GPU/CPU load.
+//
+// IMPORTANT: We use visibility: hidden (not content-visibility: hidden) because:
+// 1. content-visibility: hidden is not supported on all mobile browsers
+// 2. On devices where it's unsupported, only opacity: 0 took effect,
+//    and if the overlay hadn't rendered yet (lazy-load + animation delay),
+//    the user saw a blank screen.
+//
+// The transition-delay ensures that background content stays visible for
+// a brief moment until the overlay has fully appeared on top.
 body.has-fullscreen-overlay {
   overflow: hidden;
 
-  // Hide the main application content to save GPU/CPU cycles
   main,
   header.sticky-top,
   .bottom-nav {
-    content-visibility: hidden;
-    opacity: 0;
+    visibility: hidden;
     pointer-events: none;
+    // Delay hiding so the overlay renders first on slow devices
+    transition: visibility 0s linear 0.05s;
   }
 }

--- a/assets/scss/_notes.scss
+++ b/assets/scss/_notes.scss
@@ -422,6 +422,10 @@
 
 .note-editor-modal {
   @include premium-modal(500px);
+  // Override: remove container padding — children manage their own padding.
+  // The mixin's 2.2rem padding combined with children padding caused overflow.
+  padding: 0;
+  overflow: hidden;
 }
 
 .note-editor-header {
@@ -479,6 +483,7 @@
 
 .note-editor-textarea {
   width: 100%;
+  box-sizing: border-box;
   padding: 1rem 1.25rem;
   border: none;
   font-size: 1rem;

--- a/assets/scss/_selection-grid.scss
+++ b/assets/scss/_selection-grid.scss
@@ -11,7 +11,17 @@
   @include glassmorphism-panel(0.95, 20px);
   z-index: 2000;
   overflow-y: auto;
+
+  // Desktop: smooth slide-up entrance
   @include smooth-entrance-slide-up;
+
+  // Mobile: instant appearance (no transform animation) to prevent
+  // blank screen on slow devices where background hides before overlay renders
+  @media (max-width: 991.98px) {
+    animation: fadeIn 0.15s ease-out forwards;
+    opacity: 1;
+    transform: none;
+  }
 
   @include dark-mode {
     // Background handled by mixin

--- a/assets/scss/_translation-selector.scss
+++ b/assets/scss/_translation-selector.scss
@@ -735,6 +735,4 @@
   }
 }
 
-.note-editor-modal {
-  @include premium-modal(500px);
-}
+// .note-editor-modal is defined in _notes.scss — do not duplicate here


### PR DESCRIPTION
## Problem
Na niektórych urządzeniach mobilnych (szczególnie wolniejszych) otwieranie selektora rozdziałów lub porównywarki wersetów powodowało znikanie całej strony (biały/pusty ekran). Dodatkowo okno edytora notatek (po dłuższym przytrzymaniu wersetu) było przesunięte i ucięte z prawej strony.

## Root Cause
1. **Biały ekran przy overlayach**: Race condition — CSS natychmiast ukrywał tło aplikacji (content-visibility: hidden + opacity: 0), podczas gdy overlay potrzebował czasu na załadowanie (React.lazy + animacja 0.4s).
2. **Przesunięty edytor notatek**: Technika centrowania left:50%/transform:translate(-50%,-50%) była zawodna na niektórych mobilnych przeglądarkach. Duplikat definicji CSS nadpisywał poprawki.

## Zmiany

### _mobile.scss
- Zamiana content-visibility:hidden + opacity:0 na visibility:hidden z transition-delay:0.05s
- Dodanie brakujących kolorów tekstu w dark mode dla porównywarki rozdziałów

### _selection-grid.scss
- Na mobile overlay używa szybkiego fadeIn (0.15s) zamiast wolnego slideUpFade (0.4s)

### _mixins.scss (premium-modal)
- Zamiana left:50%/transform:translate(-50%,-50%) na inset:0/margin:auto
- Usunięcie padding z mixinu — każdy modal sam zarządza paddingiem
- Dodanie max-height i height:fit-content

### _notes.scss
- padding:0 i overflow:hidden na .note-editor-modal
- box-sizing:border-box na .note-editor-textarea

### _translation-selector.scss
- Usunięcie duplikatu .note-editor-modal

## Testing
- Selektor rozdziałów — brak białego ekranu
- Porównywarka wersetów — brak białego ekranu
- Porównywarka rozdziałów — poprawny dark mode
- Edytor notatek (long press) — poprawnie wycentrowany