### PR TITLE
UI Refinements: Zen mode, dark mode, chapter navigation, and comparison grid mobile scrolling

### DIFF
--- a/assets/js/Bible.js
+++ b/assets/js/Bible.js
@@ -68,12 +68,14 @@ const Bible = ({ intl, setLocale }) => {
         return safeLocalStorageGetItem("rbiblia-font-size") || "medium";
     });
 
-    // Zen Mode — lock navigation visible (disable hide-on-scroll)
+    // Zen Mode — hides navigation on scroll (immersive reading)
+    // zenMode=true  → immersiveDisabled=false → nav hides while scrolling down
+    // zenMode=false → immersiveDisabled=true  → nav always visible
     const [zenMode, setZenMode] = useState(() => {
         return safeLocalStorageGetItem("rbiblia-zen-mode") === "1";
     });
 
-    const immersiveDisabled = zenMode || isWelcomePopupOpen;
+    const immersiveDisabled = !zenMode || isWelcomePopupOpen;
 
     // Font family (saved to localStorage)
     const [fontFamily, setFontFamily] = useState(() => {
@@ -198,6 +200,11 @@ const Bible = ({ intl, setLocale }) => {
     const keepChapterIfPossible = useRef(false);
     const startFromLastVerse = useRef(false);
 
+    // Ref to track current translation — used by changeSelectedTranslation
+    // guard without adding selectedTranslation to the callback's deps.
+    const selectedTranslationRef = useRef(selectedTranslation);
+    selectedTranslationRef.current = selectedTranslation;
+
     const chapters =
         structure && selectedBook && structure[selectedBook]
             ? structure[selectedBook]
@@ -205,6 +212,12 @@ const Bible = ({ intl, setLocale }) => {
 
     const changeSelectedTranslation = useCallback(
         (newTranslation) => {
+            // Skip if translation hasn't actually changed — prevents resetting
+            // isStructureLoading when the structure fetch is already in progress
+            // or completed (avoids race condition on initial load / locale change).
+            if (newTranslation === selectedTranslationRef.current) {
+                return;
+            }
             setShowVerses(false);
             setIsStructureLoading(true);
             keepChapterIfPossible.current = true;
@@ -292,6 +305,12 @@ const Bible = ({ intl, setLocale }) => {
             setSelectedChapter(newSelectedChapter);
             setVerses(result.data);
             setShowVerses(true);
+
+            // Always scroll to top when a new chapter loads.
+            // 'instant' prevents a visible scroll animation fighting the
+            // content swap (especially when data comes from cache and the
+            // chapter appears without a loading state).
+            globalThis.scrollTo({ top: 0, behavior: "instant" });
 
             // Prefetch next and previous chapters in the background
             versesCache.prefetchAdjacent(
@@ -589,7 +608,7 @@ const Bible = ({ intl, setLocale }) => {
                 setHighlightedVerse(verseId);
                 setTimeout(() => {
                     setHighlightedVerse(null);
-                }, 3000);
+                }, 5000);
             }
         },
         [navigateToBookAndChapter]

--- a/assets/js/ComparisonGrid.js
+++ b/assets/js/ComparisonGrid.js
@@ -303,31 +303,6 @@ const ComparisonGrid = ({
 
     const primaryText = comparedVerses[currentTranslation];
 
-    // Dynamic unpin: if the pinned area exceeds 2/3 of viewport height on mobile, unpin it
-    const pinnedAreaRef = useRef(null);
-    const [isPinnedTooTall, setIsPinnedTooTall] = useState(false);
-
-    useEffect(() => {
-        const el = pinnedAreaRef.current;
-        if (!el) return;
-
-        const checkHeight = () => {
-            const threshold = window.innerHeight * (2 / 3);
-            setIsPinnedTooTall(el.scrollHeight >= threshold);
-        };
-
-        checkHeight();
-
-        const observer = new ResizeObserver(checkHeight);
-        observer.observe(el);
-        window.addEventListener('resize', checkHeight);
-
-        return () => {
-            observer.disconnect();
-            window.removeEventListener('resize', checkHeight);
-        };
-    }, [verseId, primaryText]);
-
     const availableComparisonTexts = useMemo(() => {
         const selectedTexts = selectedTranslations
             .map((id) => comparedVerses[id])
@@ -639,8 +614,8 @@ const ComparisonGrid = ({
                 className="selection-content container"
                 style={{ position: "relative", zIndex: 1 }}
             >
-                {/* Pinned area: header + primary translation (sticky on mobile) */}
-                <div ref={pinnedAreaRef} className={`comparison-pinned-area${isPinnedTooTall ? ' comparison-pinned-unpinned' : ''}`}>
+                {/* Base verse area (scrolls with the page) */}
+                <div className="comparison-pinned-area">
                     <div className="selection-header d-flex justify-content-between align-items-center mb-3 pt-4">
                         {/* Navigation and title */}
                         <div className="comparison-nav-header">

--- a/assets/js/SideMenu.js
+++ b/assets/js/SideMenu.js
@@ -62,6 +62,7 @@ const SideMenuTab = ({ onClick, className = "", immersiveDisabled = false }) => 
 SideMenuTab.propTypes = {
     onClick: PropTypes.func,
     className: PropTypes.string,
+    immersiveDisabled: PropTypes.bool,
 };
 
 // Helper functions for settings
@@ -91,8 +92,8 @@ const saveFavoriteTranslations = (favorites) => {
         FAVORITE_TRANSLATIONS_STORAGE_KEY,
         JSON.stringify(favorites)
     );
-    if (typeof window !== "undefined") {
-        window.dispatchEvent(
+    if (globalThis.window !== undefined) {
+        globalThis.window.dispatchEvent(
             new CustomEvent(FAVORITE_TRANSLATIONS_UPDATED_EVENT, {
                 detail: favorites,
             })
@@ -143,12 +144,12 @@ const DisplaySettings = ({
             setFavoriteTranslations(getFavoriteTranslations());
         };
 
-        window.addEventListener(
+        globalThis.addEventListener(
             FAVORITE_TRANSLATIONS_UPDATED_EVENT,
             handleFavoritesUpdated
         );
         return () => {
-            window.removeEventListener(
+            globalThis.removeEventListener(
                 FAVORITE_TRANSLATIONS_UPDATED_EVENT,
                 handleFavoritesUpdated
             );
@@ -473,13 +474,13 @@ const DisplaySettings = ({
                                     </p>
                                     <div className="diff-mode-toggle">
                                         <button
-                                            className={`diff-mode-btn ${!zenMode ? "active" : ""
+                                            className={`diff-mode-btn ${zenMode ? "" : "active"
                                                 }`}
                                             onClick={() => setZenMode(false)}
                                         >
                                             {formatMessage({
-                                                id: "off",
-                                                defaultMessage: "Wył.",
+                                                id: "zenModeOff",
+                                                defaultMessage: "Wyłączony",
                                             })}
                                         </button>
                                         <button
@@ -488,8 +489,8 @@ const DisplaySettings = ({
                                             onClick={() => setZenMode(true)}
                                         >
                                             {formatMessage({
-                                                id: "on",
-                                                defaultMessage: "Wł.",
+                                                id: "zenModeOn",
+                                                defaultMessage: "Włączony",
                                             })}
                                         </button>
                                     </div>

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -53,6 +53,14 @@ $font-bible: "Crimson Text", Georgia, "Times New Roman", serif;
     border-bottom: 2px dashed $rb-header-navigator-arrow;
     @include fluid-text(1rem, 1.3rem);
   }
+
+  @include dark-mode {
+    color: var(--dm-text-primary);
+
+    &:hover {
+      color: var(--dm-accent);
+    }
+  }
 }
 
 .icon-expand {
@@ -94,6 +102,12 @@ body {
   background-size: 84px 83px;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  @include dark-mode {
+    background-image: none;
+    background-color: var(--dm-bg-base);
+    color: var(--dm-text-primary);
+  }
 }
 
 main {
@@ -102,12 +116,21 @@ main {
   min-height: calc(100vh - 53px);
   background: $rb-background-color;
 
+  @include dark-mode {
+    background: var(--dm-bg-surface);
+    border-color: var(--dm-border);
+  }
+
   .row {
     padding-top: 0.2em;
     padding-bottom: 0.2em;
 
     &:nth-child(even) {
       background: $rb-verse-even-color;
+
+      @include dark-mode {
+        background: rgba(255, 255, 255, 0.02);
+      }
     }
 
     .verse {
@@ -119,11 +142,19 @@ main {
       letter-spacing: 0.01em;
       color: #2c2c2c;
       padding: 0.5rem 0;
+
+      @include dark-mode {
+        color: var(--dm-text-primary);
+      }
     }
 
     .line {
       &:hover {
         background: $rb-verse-line-hover;
+
+        @include dark-mode {
+          background: var(--dm-bg-hover);
+        }
       }
 
       // Long-press animation
@@ -134,7 +165,11 @@ main {
 
       // Highlighted verse (e.g. from search)
       &.highlighted {
-        animation: highlightFadeOut 3s ease forwards;
+        animation: highlightFadeOut 5s ease forwards;
+
+        .verse {
+          animation: highlightBoldFadeOut 5s ease forwards;
+        }
       }
 
       @keyframes highlightFadeOut {
@@ -148,6 +183,20 @@ main {
 
         100% {
           background: transparent;
+        }
+      }
+
+      @keyframes highlightBoldFadeOut {
+        0% {
+          font-weight: 700;
+        }
+
+        60% {
+          font-weight: 700;
+        }
+
+        100% {
+          font-weight: normal;
         }
       }
 
@@ -310,6 +359,16 @@ main {
       &:hover {
         text-decoration: underline;
       }
+
+      @include dark-mode {
+        color: var(--dm-accent);
+      }
+    }
+
+    .verse-note-label {
+      @include dark-mode {
+        color: var(--dm-text-muted);
+      }
     }
   }
 
@@ -330,16 +389,35 @@ main {
       color: $rb-verse-hover-color;
       opacity: 1;
     }
+
+    @include dark-mode {
+      &:link,
+      &:visited {
+        color: var(--dm-text-secondary);
+      }
+
+      &:hover {
+        color: var(--dm-accent);
+      }
+    }
   }
 }
 
 header,
 footer>.container {
   @include rb-border;
+
+  @include dark-mode {
+    border-color: var(--dm-border);
+  }
 }
 
 header {
   background: $rb-header-background-color;
+
+  @include dark-mode {
+    background: var(--dm-bg-elevated);
+  }
 
   .icon-navigator {
     cursor: pointer;
@@ -371,6 +449,15 @@ header {
       color: $rb-header-navigator-arrow-active;
       transform: scale(0.95);
     }
+
+    @include dark-mode {
+      color: var(--dm-accent);
+
+      &:hover,
+      &:focus {
+        color: var(--dm-text-primary);
+      }
+    }
   }
 
   .icon-navigator-disabled {
@@ -384,6 +471,16 @@ header {
     &:active {
       color: $rb-header-navigator-arrow-disabled;
       background: transparent;
+    }
+
+    @include dark-mode {
+      color: var(--dm-text-muted);
+
+      &:hover,
+      &:focus,
+      &:active {
+        color: var(--dm-text-muted);
+      }
     }
   }
 
@@ -437,6 +534,17 @@ header {
   &:active {
     transform: translateY(0);
   }
+
+  @include dark-mode {
+    background: rgba(255, 255, 255, 0.08);
+    color: var(--dm-accent);
+
+    &:hover {
+      background: var(--dm-accent);
+      color: var(--dm-bg-base);
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    }
+  }
 }
 
 footer {
@@ -449,6 +557,10 @@ footer {
     background: $rb-footer-background-color;
     padding-top: 0.2em;
     padding-bottom: 0.2em;
+
+    @include dark-mode {
+      background: var(--dm-bg-elevated);
+    }
   }
 
   a {
@@ -460,6 +572,17 @@ footer {
 
     &:hover {
       color: $rb-footer-hover-color;
+    }
+
+    @include dark-mode {
+      &:link,
+      &:visited {
+        color: var(--dm-text-secondary);
+      }
+
+      &:hover {
+        color: var(--dm-accent);
+      }
     }
   }
 }
@@ -526,6 +649,15 @@ footer {
 
   main {
     min-height: calc(100vh - 162px);
+  }
+}
+
+// Skeleton row dark mode
+@include dark-mode {
+  .skeleton-row {
+    &:nth-child(even) {
+      background: rgba(255, 255, 255, 0.02);
+    }
   }
 }
 

--- a/assets/scss/_comparison-modal.scss
+++ b/assets/scss/_comparison-modal.scss
@@ -64,39 +64,9 @@
   }
 }
 
-// Pin header + primary translation while scrolling through comparisons
-.comparison-pinned-area {
-  @media (max-width: 991.98px) {
-    position: sticky;
-    top: 0;
-    z-index: 10;
-    background: rgba(255, 255, 255, 0.97);
-    padding-bottom: 0.75rem;
-    margin-left: -1rem;
-    margin-right: -1rem;
-    padding-left: 1rem;
-    padding-right: 1rem;
-    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-    will-change: transform; // Hint for browser during scroll
-
-    @include dark-mode {
-      background: rgba(30, 30, 30, 0.97);
-      border-bottom-color: rgba(255, 255, 255, 0.1);
-    }
-
-    // When primary verse is too tall (≥2/3 viewport), unpin and scroll normally
-    &.comparison-pinned-unpinned {
-      position: relative;
-      border-bottom: none;
-      background: transparent;
-      will-change: auto;
-
-      @include dark-mode {
-        background: transparent;
-      }
-    }
-  }
-}
+// .comparison-pinned-area: no sticky pinning — the entire overlay scrolls
+// freely so the user can always reach comparison slots without the base verse
+// taking up permanent viewport space on small screens.
 
 .comparison-box-header {
   display: flex;

--- a/assets/translations/de.json
+++ b/assets/translations/de.json
@@ -136,5 +136,9 @@
   "downloadWindowsLink": "rBiblia für Windows herunterladen",
   "faqLink": "Häufig gestellte Fragen (FAQ)",
   "contactLink": "Kontakt / Fehler melden",
-  "radioLink": "Radio mit dem Evangelium"
+  "radioLink": "Radio mit dem Evangelium",
+  "zenMode": "Zen-Modus",
+  "zenModeHint": "Blendet die Navigation beim Scrollen für ablenkungsfreies Lesen aus",
+  "zenModeOff": "Deaktiviert",
+  "zenModeOn": "Aktiviert"
 }

--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -136,5 +136,9 @@
   "downloadWindowsLink": "rBiblia for Windows",
   "faqLink": "FAQ",
   "contactLink": "Contact / Bug report",
-  "radioLink": "Radio with the Gospel"
+  "radioLink": "Radio with the Gospel",
+  "zenMode": "Zen Mode",
+  "zenModeHint": "Hides navigation while scrolling for distraction-free reading",
+  "zenModeOff": "Disabled",
+  "zenModeOn": "Enabled"
 }

--- a/assets/translations/pl.json
+++ b/assets/translations/pl.json
@@ -116,7 +116,7 @@
   "clear": "Wyczyść",
   "showDifferences": "Różnice",
   "hideDifferences": "Ukryj różnice",
-  "toggleDifferences": "óżnice",
+  "toggleDifferences": "różnice",
   "toggleDifferencesKeyboardHint": "Naciśnij D aby przełączyć podświetlanie różnic",
   "diffMode": "Tryb porównywania",
   "diffModeHint": "Luźny — ignoruje kolejność słów. Ścisły (LCS) — porównuje parami z bazowym, uwzględnia kolejność.",
@@ -136,5 +136,9 @@
   "downloadWindowsLink": "rBiblia na Windows",
   "faqLink": "Lista pytań (FAQ)",
   "contactLink": "Kontakt / Zgłoś błąd",
-  "radioLink": "Radio Początek"
+  "radioLink": "Radio Początek",
+  "zenMode": "Tryb Zen",
+  "zenModeHint": "Ukrywa nawigację podczas przewijania dla wygodniejszego czytania",
+  "zenModeOff": "Wyłączony",
+  "zenModeOn": "Włączony"
 }


### PR DESCRIPTION
- Added comprehensive dark mode styles to base reader elements.
- Fixed race condition in chapter navigation on initial load.
- Clarified Zen Mode status descriptions and hints across all translations.
- Ensured the reader scrolls to the top instantly when changing chapters.
- Removed sticky pinning from the comparison grid base verse on mobile.
- Resolved several linting errors in SideMenu.js.