### PR TITLE
fix(touch): clear sticky focus on nav buttons and restore tap feedback

### DIFF
--- a/assets/js/BottomNavigation.js
+++ b/assets/js/BottomNavigation.js
@@ -3,6 +3,7 @@ import { useIntl } from "react-intl";
 import PropTypes from "prop-types";
 import Icon from "./Icon";
 import useScrollDirection from "./useScrollDirection";
+import blurOnTouchInteraction from "./blurOnTouchInteraction";
 
 const BottomNavigation = memo(function BottomNavigation({
     onPrevChapter,
@@ -30,9 +31,11 @@ const BottomNavigation = memo(function BottomNavigation({
             <button
                 className="bottom-nav-btn bottom-nav-arrow"
                 onClick={(e) => {
-                    e.currentTarget.blur();
                     onPrevChapter();
+                    blurOnTouchInteraction(e);
                 }}
+                onPointerUp={blurOnTouchInteraction}
+                onTouchEnd={blurOnTouchInteraction}
                 disabled={!isPrevAvailable}
                 aria-label={formatMessage({ id: "previousChapter" })}
             >
@@ -92,9 +95,11 @@ const BottomNavigation = memo(function BottomNavigation({
             <button
                 className="bottom-nav-btn bottom-nav-arrow"
                 onClick={(e) => {
-                    e.currentTarget.blur();
                     onNextChapter();
+                    blurOnTouchInteraction(e);
                 }}
+                onPointerUp={blurOnTouchInteraction}
+                onTouchEnd={blurOnTouchInteraction}
                 disabled={!isNextAvailable}
                 aria-label={formatMessage({ id: "nextChapter" })}
             >

--- a/assets/js/ChapterComparison.js
+++ b/assets/js/ChapterComparison.js
@@ -1,3 +1,4 @@
+/* global globalThis */
 import React, {
     useState,
     useCallback,
@@ -11,6 +12,7 @@ import Icon from "./Icon";
 import { safeJsonParse } from "./safeJsonParse";
 import TranslationSelector from "./TranslationSelector";
 import { safeLocalStorageGetItem } from "./safeStorage";
+import blurOnTouchInteraction from "./blurOnTouchInteraction";
 
 const FAVORITE_TRANSLATIONS_STORAGE_KEY = "rbiblia_favorite_translations";
 
@@ -244,7 +246,12 @@ const ChapterComparison = ({
                 <div className="chapter-comp-nav">
                     <button
                         className="chapter-comp-nav-btn"
-                        onClick={goToPrevChapter}
+                        onClick={(e) => {
+                            goToPrevChapter();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         disabled={!hasPrev}
                         title={formatMessage({ id: "previousChapter" })}
                     >
@@ -256,7 +263,12 @@ const ChapterComparison = ({
                     </span>
                     <button
                         className="chapter-comp-nav-btn"
-                        onClick={goToNextChapter}
+                        onClick={(e) => {
+                            goToNextChapter();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         disabled={!hasNext}
                         title={formatMessage({ id: "nextChapter" })}
                     >

--- a/assets/js/ComparisonGrid.js
+++ b/assets/js/ComparisonGrid.js
@@ -20,6 +20,7 @@ import {
     safeLocalStorageGetItem,
     safeLocalStorageSetItem,
 } from "./safeStorage";
+import blurOnTouchInteraction from "./blurOnTouchInteraction";
 
 const COMPARISON_DIFF_MODE_KEY = "rbiblia-comparison-diff-mode";
 const WORD_SPLIT_PATTERN =
@@ -624,7 +625,12 @@ const ComparisonGrid = ({
                         <div className="comparison-nav-header">
                             <button
                                 className="comparison-nav-btn"
-                                onClick={handlePrevVerse}
+                                onClick={(e) => {
+                                    handlePrevVerse();
+                                    blurOnTouchInteraction(e);
+                                }}
+                                onPointerUp={blurOnTouchInteraction}
+                                onTouchEnd={blurOnTouchInteraction}
                                 disabled={!canGoPrev}
                                 title={formatMessage({ id: "previousVerse" })}
                             >
@@ -650,7 +656,12 @@ const ComparisonGrid = ({
 
                             <button
                                 className="comparison-nav-btn"
-                                onClick={handleNextVerse}
+                                onClick={(e) => {
+                                    handleNextVerse();
+                                    blurOnTouchInteraction(e);
+                                }}
+                                onPointerUp={blurOnTouchInteraction}
+                                onTouchEnd={blurOnTouchInteraction}
                                 disabled={!canGoNext}
                                 title={formatMessage({ id: "nextVerse" })}
                             >

--- a/assets/js/blurOnTouchInteraction.js
+++ b/assets/js/blurOnTouchInteraction.js
@@ -1,0 +1,67 @@
+const TOUCH_POINTER_TYPES = new Set(["touch", "pen"]);
+const TOUCH_TAP_FEEDBACK_CLASS = "touch-tap-feedback";
+const TOUCH_TAP_FEEDBACK_MS = 140;
+
+const setInputModality = (modality) => {
+    if (typeof document === "undefined") {
+        return;
+    }
+
+    const root = document.body;
+    if (!root || root.dataset.inputModality === modality) {
+        return;
+    }
+
+    root.dataset.inputModality = modality;
+};
+
+const blurOnTouchInteraction = (event) => {
+    const target = event?.currentTarget;
+    if (!target || typeof target.blur !== "function") {
+        return;
+    }
+    if (target.disabled) {
+        return;
+    }
+
+    const applyTouchTapFeedback = () => {
+        if (!target.classList) {
+            return;
+        }
+
+        target.classList.add(TOUCH_TAP_FEEDBACK_CLASS);
+        setTimeout(() => {
+            target.classList.remove(TOUCH_TAP_FEEDBACK_CLASS);
+        }, TOUCH_TAP_FEEDBACK_MS);
+    };
+
+    const nativeEvent = event.nativeEvent;
+    const pointerType = nativeEvent?.pointerType;
+
+    if (typeof pointerType === "string") {
+        if (pointerType === "mouse") {
+            setInputModality("mouse");
+        }
+
+        if (TOUCH_POINTER_TYPES.has(pointerType)) {
+            setInputModality("touch");
+            applyTouchTapFeedback();
+            setTimeout(() => target.blur(), 0);
+        }
+
+        return;
+    }
+
+    if (nativeEvent?.changedTouches) {
+        setInputModality("touch");
+        applyTouchTapFeedback();
+        setTimeout(() => target.blur(), 0);
+        return;
+    }
+
+    if (event.detail > 0) {
+        setTimeout(() => target.blur(), 0);
+    }
+};
+
+export default blurOnTouchInteraction;

--- a/assets/scss/_bottom-nav.scss
+++ b/assets/scss/_bottom-nav.scss
@@ -57,6 +57,10 @@
     opacity: 0.6;
   }
 
+  &.touch-tap-feedback:not(:disabled) {
+    opacity: 0.6;
+  }
+
   &:focus:not(:focus-visible) {
     outline: none;
     background: transparent;
@@ -68,8 +72,12 @@
     justify-self: center;
   }
 
-  &:hover:not(:disabled) {
-    background: rgba(0, 0, 0, 0.05);
+  @media (hover: hover) and (pointer: fine) {
+    body:not([data-input-modality="touch"]) & {
+      &:hover:not(:disabled) {
+        background: rgba(0, 0, 0, 0.05);
+      }
+    }
   }
 
   &:disabled {
@@ -80,8 +88,12 @@
   @include dark-mode {
     color: var(--dm-text-secondary);
 
-    &:hover:not(:disabled) {
-      background: var(--dm-bg-hover);
+    @media (hover: hover) and (pointer: fine) {
+      body:not([data-input-modality="touch"]) & {
+        &:hover:not(:disabled) {
+          background: var(--dm-bg-hover);
+        }
+      }
     }
   }
 }
@@ -96,10 +108,14 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
   white-space: nowrap;
 
-  &:hover:not(:disabled) {
-    background: darken($rb-header-navigator-arrow, 8%);
-    transform: translateY(-2px);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  @media (hover: hover) and (pointer: fine) {
+    body:not([data-input-modality="touch"]) & {
+      &:hover:not(:disabled) {
+        background: darken($rb-header-navigator-arrow, 8%);
+        transform: translateY(-2px);
+        box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+      }
+    }
   }
 
   .bottom-nav-icon {

--- a/assets/scss/_comparison-modal.scss
+++ b/assets/scss/_comparison-modal.scss
@@ -287,15 +287,26 @@
     stroke-width: 2.5;
   }
 
-  &:hover:not(:disabled) {
-    background: $rb-header-navigator-arrow;
-    color: white;
-    transform: scale(1.08);
-    box-shadow: 0 8px 20px rgba($rb-header-navigator-arrow, 0.3);
+  @media (hover: hover) and (pointer: fine) {
+    body:not([data-input-modality="touch"]) & {
+      &:hover:not(:disabled) {
+        background: $rb-header-navigator-arrow;
+        color: white;
+        transform: scale(1.08);
+        box-shadow: 0 8px 20px rgba($rb-header-navigator-arrow, 0.3);
+      }
+    }
   }
 
   &:active:not(:disabled) {
     transform: scale(0.95);
+  }
+
+  &.touch-tap-feedback:not(:disabled) {
+    background: $rb-header-navigator-arrow;
+    color: white;
+    transform: scale(0.96);
+    box-shadow: 0 6px 14px rgba($rb-header-navigator-arrow, 0.28);
   }
 
   &:disabled {
@@ -307,9 +318,19 @@
     background: var(--dm-bg-elevated);
     color: var(--dm-text-primary);
 
-    &:hover:not(:disabled) {
+    &.touch-tap-feedback:not(:disabled) {
       background: var(--dm-accent);
       color: white;
+      box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+    }
+
+    @media (hover: hover) and (pointer: fine) {
+      body:not([data-input-modality="touch"]) & {
+        &:hover:not(:disabled) {
+          background: var(--dm-accent);
+          color: white;
+        }
+      }
     }
   }
 }

--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -440,6 +440,14 @@ header.sticky-top {
   @include focus-ring;
 }
 
+// Touch devices: prevent sticky focus ring on nav arrow buttons after tap
+body[data-input-modality="touch"] .bottom-nav-btn.bottom-nav-arrow:focus-visible,
+body[data-input-modality="touch"] .chapter-comp-nav-btn:focus-visible,
+body[data-input-modality="touch"] .comparison-nav-btn:focus-visible {
+  outline: none;
+  box-shadow: none !important;
+}
+
 .chapter-comp-overlay {
   position: fixed;
   inset: 0;
@@ -639,8 +647,16 @@ header.sticky-top {
   cursor: pointer;
   transition: background 0.15s ease;
 
-  &:hover:not(:disabled) {
-    background: rgba($rb-header-navigator-arrow, 0.08);
+  @media (hover: hover) and (pointer: fine) {
+    body:not([data-input-modality="touch"]) & {
+      &:hover:not(:disabled) {
+        background: rgba($rb-header-navigator-arrow, 0.08);
+      }
+    }
+  }
+
+  &.touch-tap-feedback:not(:disabled) {
+    background: rgba($rb-header-navigator-arrow, 0.14);
   }
 
   &:disabled {


### PR DESCRIPTION
## Summary\n- remove sticky focus/highlight behavior after touch interaction for comparison and bottom navigation buttons\n- keep keyboard accessibility by avoiding blur for keyboard-initiated clicks\n- restore short tap feedback animation on touch so interactions feel responsive\n\n## Validation\n- npx.cmd eslint assets/js/BottomNavigation.js assets/js/ChapterComparison.js assets/js/ComparisonGrid.js assets/js/blurOnTouchInteraction.js\n- yarn.cmd encore dev\n\n## Merge safety\n- branch is based directly on upstream/dev\n- diff is ahead by 1 commit and behind by 0 commits versus upstream/dev