### PR TITLE
fix(mobile): restore dark tap feedback and verse highlight effect

### DIFF
--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -128,6 +128,24 @@ header.sticky-top {
   .favorite-translation-item:hover {
     transform: none !important;
   }
+
+  // Keep search-result verse highlight animation unchanged across devices.
+  // This intentionally overrides reduced-motion defaults for this one effect.
+  .line.highlighted {
+    animation: highlightPulseFade 8s ease-out forwards !important;
+    animation-duration: 8s !important;
+    animation-iteration-count: 1 !important;
+
+    @include dark-mode {
+      animation: highlightPulseFadeDark 8s ease-out forwards !important;
+    }
+
+    .verse {
+      animation: highlightBoldFadeOut 8s ease-out forwards !important;
+      animation-duration: 8s !important;
+      animation-iteration-count: 1 !important;
+    }
+  }
 }
 
 // Dark mode skeleton fix for reduced motion

--- a/assets/scss/_side-menu.scss
+++ b/assets/scss/_side-menu.scss
@@ -159,6 +159,11 @@
     color: #444;
   }
 
+  &:active:not(:disabled):not(.active) {
+    background: rgba(0, 0, 0, 0.1);
+    color: #333;
+  }
+
   &.active {
     background: $rb-header-navigator-arrow;
     color: white;
@@ -169,6 +174,11 @@
     &:hover {
       background: rgba(255, 255, 255, 0.08);
       color: #eee;
+    }
+
+    &:active:not(:disabled):not(.active) {
+      background: rgba(255, 255, 255, 0.14);
+      color: #fff;
     }
 
     &.active {


### PR DESCRIPTION
Summary: fix side-menu dock tap icon colors in dark mode and preserve verse highlight bold+bounce animation under reduced-motion overrides. Testing: yarn encore dev.