### PR TITLE
fix(mobile): block bib:// deep link on verse numbers and stabilize touch overlays

### DIFF
--- a/assets/js/Bible.js
+++ b/assets/js/Bible.js
@@ -41,6 +41,10 @@ const SearchPanel = React.lazy(() => import("./SearchPanel"));
 const ChapterComparison = React.lazy(() => import("./ChapterComparison"));
 const ChangelogModal = React.lazy(() => import("./ChangelogModal"));
 
+const FullscreenOverlayFallback = () => (
+    <div className="selection-overlay" aria-hidden="true" />
+);
+
 const Bible = ({ intl, setLocale }) => {
     const [error, setError] = useState(null);
     const [toastError, setToastError] = useState(null); // Non-blocking error notifications
@@ -730,7 +734,7 @@ const Bible = ({ intl, setLocale }) => {
                 onOpenChapterComparison={handleOpenChapterComp}
                 immersiveDisabled={immersiveDisabled}
             />
-            <Suspense fallback={null}>
+            <Suspense fallback={<FullscreenOverlayFallback />}>
                 {isSelectionOpen && (
                     <SelectionGrid
                         books={books}
@@ -795,7 +799,11 @@ const Bible = ({ intl, setLocale }) => {
                 onNavigateToVerse={handleNavigateToVerse}
             />
             {/* Lazy Loaded Panels */}
-            <Suspense fallback={null}>
+            <Suspense
+                fallback={
+                    isChapterCompOpen ? <FullscreenOverlayFallback /> : null
+                }
+            >
                 <SearchPanel
                     isOpen={isSearchOpen}
                     onClose={handleCloseSearch}

--- a/assets/js/Navigator.js
+++ b/assets/js/Navigator.js
@@ -5,6 +5,7 @@ import DirectionalNavigationButton from "./DirectionalNavigationButton";
 import PropTypes from "prop-types";
 import useScrollDirection from "./useScrollDirection";
 import Icon from "./Icon";
+import blurOnTouchInteraction from "./blurOnTouchInteraction";
 
 const Navigator = memo(function Navigator({
     translations,
@@ -60,7 +61,12 @@ const Navigator = memo(function Navigator({
                 <div className="col-2 d-lg-none d-flex justify-content-end ps-0">
                     <button
                         className="nav-action-btn d-flex justify-content-center align-items-center"
-                        onClick={onOpenSearch}
+                        onClick={(e) => {
+                            onOpenSearch();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         title={formatMessage({ id: "search" })}
                         style={{
                             width: "44px",
@@ -123,28 +129,48 @@ const Navigator = memo(function Navigator({
                 <div className="col-3 d-none d-lg-flex justify-content-end gap-2">
                     <button
                         className="nav-action-btn"
-                        onClick={onOpenSelection}
+                        onClick={(e) => {
+                            onOpenSelection();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         title={formatMessage({ id: "selectBook" })}
                     >
                         <Icon name="book-marked" size={20} />
                     </button>
                     <button
                         className="nav-action-btn"
-                        onClick={onOpenSearch}
+                        onClick={(e) => {
+                            onOpenSearch();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         title={formatMessage({ id: "search" })}
                     >
                         <Icon name="search" size={20} />
                     </button>
                     <button
                         className="nav-action-btn"
-                        onClick={onOpenNotes}
+                        onClick={(e) => {
+                            onOpenNotes();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         title={formatMessage({ id: "notes" })}
                     >
                         <Icon name="file-text" size={20} />
                     </button>
                     <button
                         className="nav-action-btn"
-                        onClick={onOpenChapterComparison}
+                        onClick={(e) => {
+                            onOpenChapterComparison();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         title={formatMessage({ id: "chapterComparison" })}
                     >
                         <svg
@@ -167,7 +193,12 @@ const Navigator = memo(function Navigator({
                     </button>
                     <button
                         className="nav-action-btn"
-                        onClick={onOpenSettings}
+                        onClick={(e) => {
+                            onOpenSettings();
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         title={formatMessage({ id: "settings" })}
                     >
                         <Icon name="settings" size={20} />

--- a/assets/js/Notes.js
+++ b/assets/js/Notes.js
@@ -10,6 +10,8 @@ import {
 const NOTES_STORAGE_KEY = "rbiblia_notes";
 const GENERAL_NOTES_KEY = "rbiblia_general_notes";
 const TRANSLATION_NOTES_KEY = "rbiblia_translation_notes";
+const GENERAL_NOTE_PREVIEW_LIMIT = 100;
+const VERSE_NOTE_PREVIEW_LIMIT = 100;
 
 /**
  * Get verse key for storage
@@ -245,10 +247,15 @@ const NotesPanel = ({
     const [translationNotes, setTranslationNotes] = useState({});
     const [generalNotes, setGeneralNotes] = useState([]);
     const [filter, setFilter] = useState("current"); // "current" | "all" | "general"
-    const [editingNote, setEditingNote] = useState(null);
-    const [editText, setEditText] = useState("");
     const [isAddingGeneral, setIsAddingGeneral] = useState(false);
     const [newGeneralNote, setNewGeneralNote] = useState("");
+    const [selectedGeneralNote, setSelectedGeneralNote] = useState(null);
+    const [isEditingGeneralPreview, setIsEditingGeneralPreview] =
+        useState(false);
+    const [generalPreviewDraft, setGeneralPreviewDraft] = useState("");
+    const [selectedVerseNote, setSelectedVerseNote] = useState(null);
+    const [isEditingVersePreview, setIsEditingVersePreview] = useState(false);
+    const [versePreviewDraft, setVersePreviewDraft] = useState("");
     const [importMessage, setImportMessage] = useState(null);
 
     // Focus trap for keyboard navigation
@@ -261,7 +268,20 @@ const NotesPanel = ({
             setTranslationNotes(loadTranslationNotes());
             setGeneralNotes(loadGeneralNotes());
             setImportMessage(null);
+            setSelectedGeneralNote(null);
+            setIsEditingGeneralPreview(false);
+            setGeneralPreviewDraft("");
+            setSelectedVerseNote(null);
+            setIsEditingVersePreview(false);
+            setVersePreviewDraft("");
+            return;
         }
+        setSelectedGeneralNote(null);
+        setIsEditingGeneralPreview(false);
+        setGeneralPreviewDraft("");
+        setSelectedVerseNote(null);
+        setIsEditingVersePreview(false);
+        setVersePreviewDraft("");
     }, [isOpen]);
 
     // Get filtered notes — returns array of [key, text, type] where type is "global" or "translation"
@@ -323,40 +343,6 @@ const NotesPanel = ({
         return books[bookId]?.name || bookId;
     };
 
-    // Start editing
-    const startEdit = (key, text) => {
-        setEditingNote(key);
-        setEditText(text);
-    };
-
-    // Save edit
-    const saveEdit = (type) => {
-        if (!editingNote) return;
-
-        if (type === "translation") {
-            const updatedNotes = { ...translationNotes };
-            if (editText.trim()) {
-                updatedNotes[editingNote] = editText.trim();
-            } else {
-                delete updatedNotes[editingNote];
-            }
-            setTranslationNotes(updatedNotes);
-            saveTranslationNotes(updatedNotes);
-        } else {
-            const updatedNotes = { ...notes };
-            if (editText.trim()) {
-                updatedNotes[editingNote] = editText.trim();
-            } else {
-                delete updatedNotes[editingNote];
-            }
-            setNotes(updatedNotes);
-            saveNotes(updatedNotes);
-        }
-
-        setEditingNote(null);
-        setEditText("");
-    };
-
     // Delete note
     const deleteNote = (key, type) => {
         if (type === "translation") {
@@ -369,6 +355,12 @@ const NotesPanel = ({
             delete updatedNotes[key];
             setNotes(updatedNotes);
             saveNotes(updatedNotes);
+        }
+
+        if (selectedVerseNote?.key === key) {
+            setSelectedVerseNote(null);
+            setIsEditingVersePreview(false);
+            setVersePreviewDraft("");
         }
     };
 
@@ -394,6 +386,123 @@ const NotesPanel = ({
         const updated = generalNotes.filter((n) => n.id !== id);
         setGeneralNotes(updated);
         saveGeneralNotes(updated);
+
+        if (selectedGeneralNote?.id === id) {
+            setSelectedGeneralNote(null);
+            setIsEditingGeneralPreview(false);
+            setGeneralPreviewDraft("");
+        }
+    };
+
+    const getGeneralNotePreviewText = (text) => {
+        const trimmed = (text || "").trim();
+        if (trimmed.length <= GENERAL_NOTE_PREVIEW_LIMIT) {
+            return trimmed;
+        }
+        return `${trimmed.slice(0, GENERAL_NOTE_PREVIEW_LIMIT)} ${formatMessage(
+            {
+                id: "showMore",
+                defaultMessage: "więcej",
+            }
+        )}...`;
+    };
+
+    const getVerseNotePreviewText = (text) => {
+        const trimmed = (text || "").trim();
+        if (trimmed.length <= VERSE_NOTE_PREVIEW_LIMIT) {
+            return trimmed;
+        }
+        return `${trimmed.slice(0, VERSE_NOTE_PREVIEW_LIMIT)} ${formatMessage(
+            {
+                id: "showMore",
+                defaultMessage: "więcej",
+            }
+        )}...`;
+    };
+
+    const openGeneralNotePreview = (note) => {
+        setSelectedVerseNote(null);
+        setIsEditingVersePreview(false);
+        setVersePreviewDraft("");
+        setSelectedGeneralNote(note);
+        setIsEditingGeneralPreview(false);
+        setGeneralPreviewDraft(note.text || "");
+    };
+
+    const closeGeneralNotePreview = () => {
+        setSelectedGeneralNote(null);
+        setIsEditingGeneralPreview(false);
+        setGeneralPreviewDraft("");
+    };
+
+    const openVerseNotePreview = (note, startEditing = false) => {
+        setSelectedGeneralNote(null);
+        setIsEditingGeneralPreview(false);
+        setGeneralPreviewDraft("");
+        setSelectedVerseNote(note);
+        setVersePreviewDraft(note.text || "");
+        setIsEditingVersePreview(startEditing);
+    };
+
+    const closeVerseNotePreview = () => {
+        setSelectedVerseNote(null);
+        setIsEditingVersePreview(false);
+        setVersePreviewDraft("");
+    };
+
+    const startEditGeneralNotePreview = () => {
+        if (!selectedGeneralNote) return;
+        setGeneralPreviewDraft(selectedGeneralNote.text || "");
+        setIsEditingGeneralPreview(true);
+    };
+
+    const saveGeneralNoteFromPreview = () => {
+        if (!selectedGeneralNote) return;
+        const updatedText = generalPreviewDraft.trim();
+        if (!updatedText) return;
+
+        const updated = generalNotes.map((note) =>
+            note.id === selectedGeneralNote.id
+                ? {
+                      ...note,
+                      text: updatedText,
+                      updatedAt: new Date().toISOString(),
+                  }
+                : note
+        );
+
+        setGeneralNotes(updated);
+        saveGeneralNotes(updated);
+
+        const refreshedSelectedNote =
+            updated.find((note) => note.id === selectedGeneralNote.id) || null;
+        setSelectedGeneralNote(refreshedSelectedNote);
+        setIsEditingGeneralPreview(false);
+    };
+
+    const saveVerseNoteFromPreview = () => {
+        if (!selectedVerseNote) return;
+        const updatedText = versePreviewDraft.trim();
+        if (!updatedText) return;
+
+        if (selectedVerseNote.type === "translation") {
+            const updatedNotes = {
+                ...translationNotes,
+                [selectedVerseNote.key]: updatedText,
+            };
+            setTranslationNotes(updatedNotes);
+            saveTranslationNotes(updatedNotes);
+        } else {
+            const updatedNotes = { ...notes, [selectedVerseNote.key]: updatedText };
+            setNotes(updatedNotes);
+            saveNotes(updatedNotes);
+        }
+
+        setSelectedVerseNote({
+            ...selectedVerseNote,
+            text: updatedText,
+        });
+        setIsEditingVersePreview(false);
     };
 
     // Navigate to verse
@@ -663,7 +772,27 @@ const NotesPanel = ({
                             ) : (
                                 <ul className="notes-list">
                                     {generalNotes.map((note) => (
-                                        <li key={note.id} className="note-item">
+                                        <li
+                                            key={note.id}
+                                            className="note-item general-note-item"
+                                            onClick={() =>
+                                                openGeneralNotePreview(note)
+                                            }
+                                            role="button"
+                                            tabIndex={0}
+                                            onKeyDown={(e) => {
+                                                if (e.target !== e.currentTarget) {
+                                                    return;
+                                                }
+                                                if (
+                                                    e.key === "Enter" ||
+                                                    e.key === " "
+                                                ) {
+                                                    e.preventDefault();
+                                                    openGeneralNotePreview(note);
+                                                }
+                                            }}
+                                        >
                                             <div className="note-header">
                                                 <span className="note-date">
                                                     {new Date(
@@ -672,11 +801,12 @@ const NotesPanel = ({
                                                 </span>
                                                 <button
                                                     className="note-action-btn note-action-delete"
-                                                    onClick={() =>
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
                                                         deleteGeneralNote(
                                                             note.id
-                                                        )
-                                                    }
+                                                        );
+                                                    }}
                                                     title={formatMessage({
                                                         id: "delete",
                                                     })}
@@ -693,7 +823,9 @@ const NotesPanel = ({
                                                 </button>
                                             </div>
                                             <p className="note-text">
-                                                {note.text}
+                                                {getGeneralNotePreviewText(
+                                                    note.text
+                                                )}
                                             </p>
                                         </li>
                                     ))}
@@ -740,24 +872,56 @@ const NotesPanel = ({
                                         ([key, text, type, translationId]) => {
                                             const { book, chapter, verse } =
                                                 parseNoteKey(key, type);
-                                            const isEditing =
-                                                editingNote === key;
+                                            const verseNote = {
+                                                key,
+                                                text,
+                                                type,
+                                                translationId,
+                                                book,
+                                                chapter,
+                                                verse,
+                                            };
 
                                             return (
                                                 <li
                                                     key={key}
-                                                    className="note-item"
+                                                    className="note-item verse-note-item"
+                                                    onClick={() =>
+                                                        openVerseNotePreview(
+                                                            verseNote
+                                                        )
+                                                    }
+                                                    role="button"
+                                                    tabIndex={0}
+                                                    onKeyDown={(e) => {
+                                                        if (
+                                                            e.target !==
+                                                            e.currentTarget
+                                                        ) {
+                                                            return;
+                                                        }
+                                                        if (
+                                                            e.key === "Enter" ||
+                                                            e.key === " "
+                                                        ) {
+                                                            e.preventDefault();
+                                                            openVerseNotePreview(
+                                                                verseNote
+                                                            );
+                                                        }
+                                                    }}
                                                 >
                                                     <div className="note-header">
                                                         <div className="note-header-left">
                                                             <button
                                                                 className="note-reference"
-                                                                onClick={() =>
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
                                                                     handleNavigate(
                                                                         key,
                                                                         type
-                                                                    )
-                                                                }
+                                                                    );
+                                                                }}
                                                             >
                                                                 {getBookName(
                                                                     book
@@ -786,111 +950,64 @@ const NotesPanel = ({
                                                             </span>
                                                         </div>
                                                         <div className="note-actions">
-                                                            {!isEditing && (
-                                                                <>
-                                                                    <button
-                                                                        className="note-action-btn"
-                                                                        onClick={() =>
-                                                                            startEdit(
-                                                                                key,
-                                                                                text
-                                                                            )
-                                                                        }
-                                                                        title={formatMessage(
-                                                                            {
-                                                                                id: "edit",
-                                                                            }
-                                                                        )}
-                                                                    >
-                                                                        <svg
-                                                                            viewBox="0 0 24 24"
-                                                                            fill="none"
-                                                                            stroke="currentColor"
-                                                                            strokeWidth="2"
-                                                                        >
-                                                                            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
-                                                                            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
-                                                                        </svg>
-                                                                    </button>
-                                                                    <button
-                                                                        className="note-action-btn note-action-delete"
-                                                                        onClick={() =>
-                                                                            deleteNote(
-                                                                                key,
-                                                                                type
-                                                                            )
-                                                                        }
-                                                                        title={formatMessage(
-                                                                            {
-                                                                                id: "delete",
-                                                                            }
-                                                                        )}
-                                                                    >
-                                                                        <svg
-                                                                            viewBox="0 0 24 24"
-                                                                            fill="none"
-                                                                            stroke="currentColor"
-                                                                            strokeWidth="2"
-                                                                        >
-                                                                            <polyline points="3 6 5 6 21 6"></polyline>
-                                                                            <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
-                                                                        </svg>
-                                                                    </button>
-                                                                </>
-                                                            )}
+                                                            <button
+                                                                className="note-action-btn"
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    openVerseNotePreview(
+                                                                        verseNote,
+                                                                        true
+                                                                    );
+                                                                }}
+                                                                title={formatMessage(
+                                                                    {
+                                                                        id: "edit",
+                                                                    }
+                                                                )}
+                                                            >
+                                                                <svg
+                                                                    viewBox="0 0 24 24"
+                                                                    fill="none"
+                                                                    stroke="currentColor"
+                                                                    strokeWidth="2"
+                                                                >
+                                                                    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"></path>
+                                                                    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"></path>
+                                                                </svg>
+                                                            </button>
+                                                            <button
+                                                                className="note-action-btn note-action-delete"
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    deleteNote(
+                                                                        key,
+                                                                        type
+                                                                    );
+                                                                }}
+                                                                title={formatMessage(
+                                                                    {
+                                                                        id: "delete",
+                                                                    }
+                                                                )}
+                                                            >
+                                                                <svg
+                                                                    viewBox="0 0 24 24"
+                                                                    fill="none"
+                                                                    stroke="currentColor"
+                                                                    strokeWidth="2"
+                                                                >
+                                                                    <polyline points="3 6 5 6 21 6"></polyline>
+                                                                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+                                                                </svg>
+                                                            </button>
                                                         </div>
                                                     </div>
 
-                                                    {isEditing ? (
-                                                        <div className="note-edit">
-                                                            <textarea
-                                                                className="note-textarea"
-                                                                value={editText}
-                                                                onChange={(e) =>
-                                                                    setEditText(
-                                                                        e.target
-                                                                            .value
-                                                                    )
-                                                                }
-                                                                autoFocus
-                                                                rows={3}
-                                                            />
-                                                            <div className="note-edit-actions">
-                                                                <button
-                                                                    className="note-edit-btn note-edit-cancel"
-                                                                    onClick={() =>
-                                                                        setEditingNote(
-                                                                            null
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    {formatMessage(
-                                                                        {
-                                                                            id: "cancel",
-                                                                        }
-                                                                    )}
-                                                                </button>
-                                                                <button
-                                                                    className="note-edit-btn note-edit-save"
-                                                                    onClick={() =>
-                                                                        saveEdit(
-                                                                            type
-                                                                        )
-                                                                    }
-                                                                >
-                                                                    {formatMessage(
-                                                                        {
-                                                                            id: "save",
-                                                                        }
-                                                                    )}
-                                                                </button>
-                                                            </div>
-                                                        </div>
-                                                    ) : (
-                                                        <p className="note-text">
-                                                            {text}
-                                                        </p>
-                                                    )}
+                                                    <p className="note-text">
+                                                        {getVerseNotePreviewText(
+                                                            text
+                                                        )}
+                                                    </p>
                                                 </li>
                                             );
                                         }
@@ -901,6 +1018,198 @@ const NotesPanel = ({
                     )}
                 </div>
             </div>
+
+            {isOpen && selectedGeneralNote && (
+                <div
+                    className="general-note-preview-overlay"
+                    onClick={closeGeneralNotePreview}
+                    role="presentation"
+                >
+                    <div
+                        className="general-note-preview-modal"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div className="general-note-preview-header">
+                            <h4 className="general-note-preview-title">
+                                {formatMessage({ id: "generalNotes" })}
+                            </h4>
+                            <button
+                                className="notes-close general-note-preview-close"
+                                onClick={closeGeneralNotePreview}
+                                title={formatMessage({ id: "close" })}
+                            >
+                                <svg
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                >
+                                    <line x1="18" y1="6" x2="6" y2="18"></line>
+                                    <line x1="6" y1="6" x2="18" y2="18"></line>
+                                </svg>
+                            </button>
+                        </div>
+                        <div className="general-note-preview-body">
+                            <span className="note-date">
+                                {new Date(
+                                    selectedGeneralNote.createdAt
+                                ).toLocaleDateString()}
+                            </span>
+                            {isEditingGeneralPreview ? (
+                                <textarea
+                                    className="note-textarea general-note-preview-textarea"
+                                    value={generalPreviewDraft}
+                                    onChange={(e) =>
+                                        setGeneralPreviewDraft(e.target.value)
+                                    }
+                                    autoFocus
+                                    rows={6}
+                                />
+                            ) : (
+                                <p className="note-text general-note-preview-text">
+                                    {selectedGeneralNote.text}
+                                </p>
+                            )}
+                        </div>
+                        <div className="note-edit-actions general-note-preview-actions">
+                            {isEditingGeneralPreview ? (
+                                <>
+                                    <button
+                                        className="note-edit-btn note-edit-cancel"
+                                        onClick={() => {
+                                            setIsEditingGeneralPreview(false);
+                                            setGeneralPreviewDraft(
+                                                selectedGeneralNote.text || ""
+                                            );
+                                        }}
+                                    >
+                                        {formatMessage({ id: "cancel" })}
+                                    </button>
+                                    <button
+                                        className="note-edit-btn note-edit-save"
+                                        onClick={saveGeneralNoteFromPreview}
+                                        disabled={!generalPreviewDraft.trim()}
+                                    >
+                                        {formatMessage({ id: "save" })}
+                                    </button>
+                                </>
+                            ) : (
+                                <button
+                                    className="note-edit-btn note-edit-save"
+                                    onClick={startEditGeneralNotePreview}
+                                >
+                                    {formatMessage({ id: "edit" })}
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
+
+            {isOpen && selectedVerseNote && (
+                <div
+                    className="general-note-preview-overlay"
+                    onClick={closeVerseNotePreview}
+                    role="presentation"
+                >
+                    <div
+                        className="general-note-preview-modal"
+                        onClick={(e) => e.stopPropagation()}
+                    >
+                        <div className="general-note-preview-header">
+                            <h4 className="general-note-preview-title">
+                                {formatMessage({ id: "noteFor" })}{" "}
+                                {getBookName(selectedVerseNote.book)}{" "}
+                                {selectedVerseNote.chapter}:
+                                {selectedVerseNote.verse}
+                            </h4>
+                            <button
+                                className="notes-close general-note-preview-close"
+                                onClick={closeVerseNotePreview}
+                                title={formatMessage({ id: "close" })}
+                            >
+                                <svg
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="currentColor"
+                                    strokeWidth="2"
+                                >
+                                    <line x1="18" y1="6" x2="6" y2="18"></line>
+                                    <line x1="6" y1="6" x2="18" y2="18"></line>
+                                </svg>
+                            </button>
+                        </div>
+                        <div className="general-note-preview-body">
+                            <span
+                                className={`note-type-badge ${
+                                    selectedVerseNote.type === "translation"
+                                        ? "note-type-translation"
+                                        : "note-type-global"
+                                }`}
+                            >
+                                {selectedVerseNote.type === "translation"
+                                    ? getTranslationName(
+                                          selectedVerseNote.translationId
+                                      )
+                                    : formatMessage({
+                                          id: "noteGlobal",
+                                      })}
+                            </span>
+                            {isEditingVersePreview ? (
+                                <textarea
+                                    className="note-textarea general-note-preview-textarea"
+                                    value={versePreviewDraft}
+                                    onChange={(e) =>
+                                        setVersePreviewDraft(e.target.value)
+                                    }
+                                    autoFocus
+                                    rows={6}
+                                />
+                            ) : (
+                                <p className="note-text general-note-preview-text">
+                                    {selectedVerseNote.text}
+                                </p>
+                            )}
+                        </div>
+                        <div className="note-edit-actions general-note-preview-actions">
+                            {isEditingVersePreview ? (
+                                <>
+                                    <button
+                                        className="note-edit-btn note-edit-cancel"
+                                        onClick={() => {
+                                            setIsEditingVersePreview(false);
+                                            setVersePreviewDraft(
+                                                selectedVerseNote.text || ""
+                                            );
+                                        }}
+                                    >
+                                        {formatMessage({ id: "cancel" })}
+                                    </button>
+                                    <button
+                                        className="note-edit-btn note-edit-save"
+                                        onClick={saveVerseNoteFromPreview}
+                                        disabled={!versePreviewDraft.trim()}
+                                    >
+                                        {formatMessage({ id: "save" })}
+                                    </button>
+                                </>
+                            ) : (
+                                <button
+                                    className="note-edit-btn note-edit-save"
+                                    onClick={() =>
+                                        openVerseNotePreview(
+                                            selectedVerseNote,
+                                            true
+                                        )
+                                    }
+                                >
+                                    {formatMessage({ id: "edit" })}
+                                </button>
+                            )}
+                        </div>
+                    </div>
+                </div>
+            )}
         </>
     );
 };

--- a/assets/js/SideMenu.js
+++ b/assets/js/SideMenu.js
@@ -5,6 +5,7 @@ import { useIntl } from "react-intl";
 import useFocusTrap from "./hooks/useFocusTrap";
 import useScrollDirection from "./useScrollDirection";
 import Icon from "./Icon";
+import blurOnTouchInteraction from "./blurOnTouchInteraction";
 import {
     safeLocalStorageGetItem,
     safeLocalStorageSetItem,
@@ -60,7 +61,12 @@ const SideMenuTab = ({
             className={`side-menu-tab ${className} ${
                 isNavVisible ? "" : "nav-hidden-fab"
             }`}
-            onClick={onClick}
+            onClick={(e) => {
+                onClick?.(e);
+                blurOnTouchInteraction(e);
+            }}
+            onPointerUp={blurOnTouchInteraction}
+            onTouchEnd={blurOnTouchInteraction}
             aria-label={formatMessage({ id: "openMenu" })}
         >
             <Icon name="settings" />
@@ -277,7 +283,12 @@ const DisplaySettings = ({
                         className={`side-menu-dock-item ${
                             activeTab === tab.id ? "active" : ""
                         }`}
-                        onClick={() => setActiveTab(tab.id)}
+                        onClick={(e) => {
+                            setActiveTab(tab.id);
+                            blurOnTouchInteraction(e);
+                        }}
+                        onPointerUp={blurOnTouchInteraction}
+                        onTouchEnd={blurOnTouchInteraction}
                         title={tab.label}
                     >
                         {tab.icon}
@@ -293,7 +304,12 @@ const DisplaySettings = ({
                     {onClose && (
                         <button
                             className="side-menu-close"
-                            onClick={onClose}
+                            onClick={(e) => {
+                                onClose(e);
+                                blurOnTouchInteraction(e);
+                            }}
+                            onPointerUp={blurOnTouchInteraction}
+                            onTouchEnd={blurOnTouchInteraction}
                             aria-label={formatMessage({ id: "close" })}
                         >
                             <Icon name="x" />

--- a/assets/js/Verse.js
+++ b/assets/js/Verse.js
@@ -7,6 +7,20 @@ const LONG_PRESS_DURATION = 500; // ms
 const NOTE_PREVIEW_TOGGLE_THRESHOLD = 80;
 const VERSE_ACTIONS_GAP_PX = 6;
 
+const shouldBlockAppDeepLink = () => {
+    if (
+        typeof globalThis === "undefined" ||
+        typeof globalThis.matchMedia !== "function"
+    ) {
+        return false;
+    }
+
+    return (
+        globalThis.matchMedia("(hover: none) and (pointer: coarse)").matches ||
+        globalThis.matchMedia("(max-width: 991.98px)").matches
+    );
+};
+
 const Verse = memo(function Verse({
     verseContent,
     bookId,
@@ -141,7 +155,12 @@ const Verse = memo(function Verse({
                 <a
                     href={appLink}
                     title={formatMessage({ id: "linkOpenInRBibliaApp" })}
-                    onClick={(e) => e.stopPropagation()}
+                    onClick={(e) => {
+                        if (shouldBlockAppDeepLink()) {
+                            e.preventDefault();
+                        }
+                        e.stopPropagation();
+                    }}
                 >
                     {chapterId}:{verseId}
                 </a>

--- a/assets/js/hooks/useFocusTrap.js
+++ b/assets/js/hooks/useFocusTrap.js
@@ -94,7 +94,17 @@ const useFocusTrap = (isOpen, onClose) => {
                 previousActiveElement.current &&
                 previousActiveElement.current.focus
             ) {
-                previousActiveElement.current.focus();
+                // Avoid browser auto-scrolling the page when restoring focus.
+                // This can fight verse scrollIntoView after selecting a search result,
+                // especially in Chromium-based browsers (e.g. Brave).
+                try {
+                    previousActiveElement.current.focus({
+                        preventScroll: true,
+                    });
+                } catch {
+                    // Fallback for older browsers that don't support focus options
+                    previousActiveElement.current.focus();
+                }
             }
         };
     }, [isOpen, onClose]);

--- a/assets/scss/_base.scss
+++ b/assets/scss/_base.scss
@@ -142,6 +142,7 @@ main {
       letter-spacing: 0.01em;
       color: #2c2c2c;
       padding: 0.5rem 0;
+      display: inline-block; /* keep stable layout after highlight ends */
 
       @include dark-mode {
         color: var(--dm-text-primary);
@@ -173,7 +174,6 @@ main {
 
         .verse {
           animation: highlightBoldFadeOut 8s ease-out forwards;
-          display: inline-block; /* allows transform to work smoothly */
         }
       }
 
@@ -525,6 +525,8 @@ header {
   display: flex;
   align-items: center;
   justify-content: center;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
   @include interactive-scale;
 
   svg {
@@ -532,25 +534,41 @@ header {
     height: 20px;
   }
 
-  &:hover {
-    background: $rb-header-navigator-arrow;
-    color: white;
-    transform: translateY(-2px);
-    box-shadow: 0 4px 12px rgba($rb-header-navigator-arrow, 0.3);
+  &:focus:not(:focus-visible) {
+    outline: none;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    body:not([data-input-modality="touch"]) & {
+      &:hover {
+        background: $rb-header-navigator-arrow;
+        color: white;
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba($rb-header-navigator-arrow, 0.3);
+      }
+    }
   }
 
   &:active {
     transform: translateY(0);
   }
 
+  &.touch-tap-feedback:not(:disabled) {
+    opacity: 0.6;
+  }
+
   @include dark-mode {
     background: rgba(255, 255, 255, 0.08);
     color: var(--dm-accent);
 
-    &:hover {
-      background: var(--dm-accent);
-      color: var(--dm-bg-base);
-      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+    @media (hover: hover) and (pointer: fine) {
+      body:not([data-input-modality="touch"]) & {
+        &:hover {
+          background: var(--dm-accent);
+          color: var(--dm-bg-base);
+          box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        }
+      }
     }
   }
 }

--- a/assets/scss/_mobile.scss
+++ b/assets/scss/_mobile.scss
@@ -460,8 +460,12 @@ header.sticky-top {
 
 // Touch devices: prevent sticky focus ring on nav arrow buttons after tap
 body[data-input-modality="touch"] .bottom-nav-btn.bottom-nav-arrow:focus-visible,
+body[data-input-modality="touch"] .nav-action-btn:focus-visible,
 body[data-input-modality="touch"] .chapter-comp-nav-btn:focus-visible,
-body[data-input-modality="touch"] .comparison-nav-btn:focus-visible {
+body[data-input-modality="touch"] .comparison-nav-btn:focus-visible,
+body[data-input-modality="touch"] .side-menu-dock-item:focus-visible,
+body[data-input-modality="touch"] .side-menu-tab:focus-visible,
+body[data-input-modality="touch"] .side-menu-close:focus-visible {
   outline: none;
   box-shadow: none !important;
 }

--- a/assets/scss/_notes.scss
+++ b/assets/scss/_notes.scss
@@ -241,6 +241,14 @@
   }
 }
 
+.general-note-item {
+  cursor: pointer;
+}
+
+.verse-note-item {
+  cursor: pointer;
+}
+
 .note-header {
   display: flex;
   align-items: center;
@@ -688,6 +696,75 @@
   @include dark-mode {
     border-color: #444;
   }
+}
+
+.general-note-preview-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 2700;
+  background: rgba(0, 0, 0, 0.45);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+}
+
+.general-note-preview-modal {
+  width: min(560px, calc(100% - 1.5rem));
+  max-height: calc(100vh - 2.5rem);
+  overflow: hidden;
+  border-radius: 16px;
+  background: #fff;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.25);
+  display: flex;
+  flex-direction: column;
+
+  @include dark-mode {
+    background: var(--dm-bg-surface);
+    box-shadow: 0 16px 48px rgba(0, 0, 0, 0.45);
+  }
+}
+
+.general-note-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+
+  @include dark-mode {
+    border-bottom-color: rgba(255, 255, 255, 0.12);
+  }
+}
+
+.general-note-preview-title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: #333;
+
+  @include dark-mode {
+    color: var(--dm-text-primary);
+  }
+}
+
+.general-note-preview-body {
+  padding: 1rem;
+  overflow-y: auto;
+}
+
+.general-note-preview-text {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+}
+
+.general-note-preview-textarea {
+  margin-top: 0.5rem;
+}
+
+.general-note-preview-actions {
+  padding: 0 1rem 1rem;
 }
 
 // ---------------------------------------------------------

--- a/assets/scss/_side-menu.scss
+++ b/assets/scss/_side-menu.scss
@@ -145,6 +145,8 @@
   justify-content: center;
   color: #888;
   cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
   transition: all 0.2s ease;
   @include interactive-scale(0.92);
 
@@ -154,12 +156,26 @@
     stroke-width: 2.2;
   }
 
-  &:hover {
-    background: rgba(0, 0, 0, 0.05);
-    color: #444;
+  &:focus:not(:focus-visible) {
+    outline: none;
+    background: transparent;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    body:not([data-input-modality="touch"]) & {
+      &:hover:not(:disabled) {
+        background: rgba(0, 0, 0, 0.05);
+        color: #444;
+      }
+    }
   }
 
   &:active:not(:disabled):not(.active) {
+    background: rgba(0, 0, 0, 0.1);
+    color: #333;
+  }
+
+  &.touch-tap-feedback:not(:disabled):not(.active) {
     background: rgba(0, 0, 0, 0.1);
     color: #333;
   }
@@ -171,12 +187,21 @@
   }
 
   @include dark-mode {
-    &:hover {
-      background: rgba(255, 255, 255, 0.08);
-      color: #eee;
+    @media (hover: hover) and (pointer: fine) {
+      body:not([data-input-modality="touch"]) & {
+        &:hover:not(:disabled) {
+          background: rgba(255, 255, 255, 0.08);
+          color: #eee;
+        }
+      }
     }
 
     &:active:not(:disabled):not(.active) {
+      background: rgba(255, 255, 255, 0.14);
+      color: #fff;
+    }
+
+    &.touch-tap-feedback:not(:disabled):not(.active) {
       background: rgba(255, 255, 255, 0.14);
       color: #fff;
     }


### PR DESCRIPTION
Summary:\n- block ib:// deep-link launch from verse-number taps on mobile/touch devices\n- unify touch tap-feedback behavior for header and side-menu actions to avoid sticky active/hover states\n- add fullscreen lazy-overlay fallback to prevent occasional blank UI while Comparison/ChapterComparison loads\n- restore focus with preventScroll in focus trap fallback path to avoid scroll conflicts\n\nTesting:\n- yarn test\n- yarn encore dev