### PR TITLE
fix(UI): prevent scroll reset when selecting search result from a different book

### DIFF
--- a/assets/js/Bible.js
+++ b/assets/js/Bible.js
@@ -390,7 +390,7 @@ const Bible = ({ intl, setLocale }) => {
             // sees the correct chapter value when useEffect fires.
             keepChapterIfPossible.current = true;
             setSelectedChapter(chapter);
-            
+
             if (book !== selectedBook) {
                 skipNextBookEffect.current = true;
                 setSelectedBook(book);

--- a/assets/js/Bible.js
+++ b/assets/js/Bible.js
@@ -206,6 +206,7 @@ const Bible = ({ intl, setLocale }) => {
 
     const keepChapterIfPossible = useRef(true);
     const startFromLastVerse = useRef(false);
+    const skipNextBookEffect = useRef(false);
     // Initialize pending highlight with verse ID from URL hash if present
     const pendingHighlightRef = useRef(
         typeof globalThis !== "undefined" && globalThis.location?.hash
@@ -260,6 +261,12 @@ const Bible = ({ intl, setLocale }) => {
 
     useEffect(() => {
         if (!structure || chapters.length === 0) {
+            return;
+        }
+        if (skipNextBookEffect.current) {
+            skipNextBookEffect.current = false;
+            keepChapterIfPossible.current = false;
+            startFromLastVerse.current = false;
             return;
         }
         changeSelectedChapter(
@@ -383,10 +390,15 @@ const Bible = ({ intl, setLocale }) => {
             // sees the correct chapter value when useEffect fires.
             keepChapterIfPossible.current = true;
             setSelectedChapter(chapter);
-            setSelectedBook(book);
+            
+            if (book !== selectedBook) {
+                skipNextBookEffect.current = true;
+                setSelectedBook(book);
+            }
+
             changeSelectedChapter(chapter, book);
         },
-        [changeSelectedChapter]
+        [changeSelectedChapter, selectedBook]
     );
 
     const loadTranslationsAndBooks = () => {


### PR DESCRIPTION
## Problem

When selecting a search result from a **different book** than the one currently open, the page always scrolled back to the top instead of scrolling to the highlighted verse.

The issue did **not** occur when selecting a result from the **same book** (but a different chapter).

## Root Cause

In 
avigateToBookAndChapter(), two parallel operations were triggered simultaneously:

1. **Direct call** to changeSelectedChapter(chapter, book) — which correctly stores the target verse in pendingHighlightRef and navigates to it.
2. **setSelectedBook(book)** — which triggered a useEffect watching [selectedBook, structure]. This effect then fired changeSelectedChapter again *without* the pending verse context, overwriting the scroll position back to the top.

When navigating within the **same book**, setSelectedBook(book) set the same value, so React bailed out — the useEffect never fired and there was no conflict.

## Fix

Introduced a skipNextBookEffect ref flag. When 
avigateToBookAndChapter detects a **book change**, it sets the flag to 	rue before calling setSelectedBook. The useEffect checks for this flag on its next run, skips the redundant changeSelectedChapter call, and resets the flag — allowing subsequent normal navigation (swipe, keyboard, arrows) to work as expected.