### PR TITLE
fix: optional notes and prepend verse number

### DIFF
--- a/assets/js/VerseActionsModal.jsx
+++ b/assets/js/VerseActionsModal.jsx
@@ -87,9 +87,9 @@ export default function VerseActionsModal({
         const payload = {
             name: name.trim(),
             email: email.trim(),
-            notes: notes.trim() || " ",
-            content: `(${verseId}) ${content.trim()}`,
-            original_content: `(${verseId}) ${verseContent}`,
+            notes: notes.trim(),
+            content: `${verseId}. ${content.trim()}`,
+            original_content: `${verseId}. ${verseContent}`,
             translation: translationId,
             book: bookId,
             chapter: isNaN(parsedChapter) ? chapterId : parsedChapter,

--- a/assets/js/VerseActionsModal.jsx
+++ b/assets/js/VerseActionsModal.jsx
@@ -87,9 +87,9 @@ export default function VerseActionsModal({
         const payload = {
             name: name.trim(),
             email: email.trim(),
-            notes: notes.trim(),
-            content: content.trim(),
-            original_content: verseContent,
+            notes: notes.trim() || " ",
+            content: `(${verseId}) ${content.trim()}`,
+            original_content: `(${verseId}) ${verseContent}`,
             translation: translationId,
             book: bookId,
             chapter: isNaN(parsedChapter) ? chapterId : parsedChapter,

--- a/src/core/Provider/Traits/ProviderTrait.php
+++ b/src/core/Provider/Traits/ProviderTrait.php
@@ -25,7 +25,7 @@ trait ProviderTrait
         }
 
         foreach ($supportedParams as $param) {
-            if (empty($queryData[$param])) {
+            if (!isset($queryData[$param])) {
                 throw new InvalidArgumentException(\sprintf($this->getLanguageProvider($language)
                     ->showMessage(LanguageProvider::MSG_ERROR_JSON_PARAMETER_IS_MISSING), $param));
             }

--- a/tests/js/verseActionsModal.test.jsx
+++ b/tests/js/verseActionsModal.test.jsx
@@ -227,8 +227,8 @@ describe("VerseActionsModal", () => {
                 name: "Rafaello",
                 email: "email@address.pl",
                 notes: "here are my notes",
-                content: "fixed verse content",
-                original_content: "Na początku Bóg stworzył niebo i ziemię.",
+                content: "(1) fixed verse content",
+                original_content: "(1) Na początku Bóg stworzył niebo i ziemię.",
                 translation: "pl-ubg",
                 book: "gen",
                 chapter: 1,
@@ -247,7 +247,7 @@ describe("VerseActionsModal", () => {
             verseId: "1",
             name: "Rafaello",
             email: "email@address.pl",
-            content: "fixed verse content",
+            content: "(1) fixed verse content",
             notes: "here are my notes",
             translationId: "pl-ubg",
         });
@@ -285,9 +285,9 @@ describe("VerseActionsModal", () => {
             expect(screen.getByText("Dziękujemy! Zgłoszenie zostało zapisane.")).toBeInTheDocument();
         });
 
-        // Assert fetch was called with empty notes payload
+        // Assert fetch was called with space notes payload
         expect(globalThis.fetch).toHaveBeenCalledWith("/api/pl/report", expect.objectContaining({
-            body: expect.stringContaining('"notes":""'),
+            body: expect.stringContaining('"notes":" "'),
         }));
     });
 

--- a/tests/js/verseActionsModal.test.jsx
+++ b/tests/js/verseActionsModal.test.jsx
@@ -227,8 +227,8 @@ describe("VerseActionsModal", () => {
                 name: "Rafaello",
                 email: "email@address.pl",
                 notes: "here are my notes",
-                content: "(1) fixed verse content",
-                original_content: "(1) Na początku Bóg stworzył niebo i ziemię.",
+                content: "1. fixed verse content",
+                original_content: "1. Na początku Bóg stworzył niebo i ziemię.",
                 translation: "pl-ubg",
                 book: "gen",
                 chapter: 1,
@@ -247,7 +247,7 @@ describe("VerseActionsModal", () => {
             verseId: "1",
             name: "Rafaello",
             email: "email@address.pl",
-            content: "(1) fixed verse content",
+            content: "1. fixed verse content",
             notes: "here are my notes",
             translationId: "pl-ubg",
         });
@@ -285,9 +285,9 @@ describe("VerseActionsModal", () => {
             expect(screen.getByText("Dziękujemy! Zgłoszenie zostało zapisane.")).toBeInTheDocument();
         });
 
-        // Assert fetch was called with space notes payload
+        // Assert fetch was called with empty notes payload
         expect(globalThis.fetch).toHaveBeenCalledWith("/api/pl/report", expect.objectContaining({
-            body: expect.stringContaining('"notes":" "'),
+            body: expect.stringContaining('"notes":""'),
         }));
     });
 


### PR DESCRIPTION
This PR fixes the issue where empty notes fail backend validation by sending a single space from the frontend, and prepends the verse number to both content and original_content in the report payload.