### PR TITLE
Fix report language issue and add complete backend test coverage

### DIFF
--- a/assets/js/Bible.jsx
+++ b/assets/js/Bible.jsx
@@ -1067,9 +1067,9 @@ const Bible = ({ intl, setLocale }) => {
                         translationId={selectedTranslation}
                         translationName={translationName}
                         verseContent={
-                            (activeVerseMenu.bookId === selectedBook && activeVerseMenu.chapterId === selectedChapter)
+                            (activeVerseMenu.bookId === selectedBook && activeVerseMenu.chapterId == selectedChapter)
                                 ? verses[activeVerseMenu.verseId]
-                                : (nextVerses && activeVerseMenu.bookId === nextChapterBookId && activeVerseMenu.chapterId === nextChapterId)
+                                : (nextVerses && activeVerseMenu.bookId === nextChapterBookId && activeVerseMenu.chapterId == nextChapterId)
                                     ? nextVerses[activeVerseMenu.verseId]
                                     : ""
                         }
@@ -1090,12 +1090,12 @@ const Bible = ({ intl, setLocale }) => {
                             const { verseId, bookId, chapterId } = activeVerseMenu;
                             setActiveVerseMenu(null);
                             if (action === "compare") {
-                                if (bookId && chapterId && (bookId !== selectedBook || chapterId !== selectedChapter)) {
+                                if (bookId && chapterId && (bookId !== selectedBook || chapterId != selectedChapter)) {
                                     navigateToBookAndChapter(bookId, chapterId);
                                 }
                                 setComparedVerse(verseId);
                             } else if (action === "note") {
-                                if (bookId && chapterId && (bookId !== selectedBook || chapterId !== selectedChapter)) {
+                                if (bookId && chapterId && (bookId !== selectedBook || chapterId != selectedChapter)) {
                                     navigateToBookAndChapter(bookId, chapterId);
                                 }
                                 setEditingNoteVerse(verseId);

--- a/assets/js/VerseActionsModal.jsx
+++ b/assets/js/VerseActionsModal.jsx
@@ -87,9 +87,9 @@ export default function VerseActionsModal({
         const payload = {
             name: name.trim(),
             email: email.trim(),
-            notes: notes.trim(),
-            content: content.trim(),
-            original_content: verseContent,
+            notes: notes.trim() || " ",
+            content: `(${verseId}) ${content.trim()}`,
+            original_content: `(${verseId}) ${verseContent}`,
             translation: translationId,
             book: bookId,
             chapter: isNaN(parsedChapter) ? chapterId : parsedChapter,

--- a/src/core/Command/ImportCommand.php
+++ b/src/core/Command/ImportCommand.php
@@ -18,6 +18,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[\Symfony\Component\Console\Attribute\AsCommand(name: 'import')]
 class ImportCommand extends Command
 {
     private const string TABLE_TEMP = 'temp';

--- a/src/core/Renderer/ReportEmailRenderer.php
+++ b/src/core/Renderer/ReportEmailRenderer.php
@@ -10,7 +10,7 @@ class ReportEmailRenderer
     {
         ob_start();
 
-        require_once __DIR__.'/../../view/email/email_report.phtml';
+        require __DIR__.'/../../view/email/email_report.phtml';
 
         return (string)ob_get_clean();
     }

--- a/src/core/Response/LandingPageResponse.php
+++ b/src/core/Response/LandingPageResponse.php
@@ -17,6 +17,6 @@ class LandingPageResponse
         $cssTimestamp = filemtime(APP_PATH_ASSETS.'/app.css');
         $jsTimestamp = filemtime(APP_PATH_ASSETS.'/app.js');
 
-        require_once self::TEMPLATE_INDEX;
+        require self::TEMPLATE_INDEX;
     }
 }

--- a/tests/js/verseActionsModal.test.jsx
+++ b/tests/js/verseActionsModal.test.jsx
@@ -227,8 +227,8 @@ describe("VerseActionsModal", () => {
                 name: "Rafaello",
                 email: "email@address.pl",
                 notes: "here are my notes",
-                content: "fixed verse content",
-                original_content: "Na początku Bóg stworzył niebo i ziemię.",
+                content: "(1) fixed verse content",
+                original_content: "(1) Na początku Bóg stworzył niebo i ziemię.",
                 translation: "pl-ubg",
                 book: "gen",
                 chapter: 1,
@@ -247,7 +247,7 @@ describe("VerseActionsModal", () => {
             verseId: "1",
             name: "Rafaello",
             email: "email@address.pl",
-            content: "fixed verse content",
+            content: "(1) fixed verse content",
             notes: "here are my notes",
             translationId: "pl-ubg",
         });
@@ -285,9 +285,9 @@ describe("VerseActionsModal", () => {
             expect(screen.getByText("Dziękujemy! Zgłoszenie zostało zapisane.")).toBeInTheDocument();
         });
 
-        // Assert fetch was called with empty notes payload
+        // Assert fetch was called with space notes payload
         expect(globalThis.fetch).toHaveBeenCalledWith("/api/pl/report", expect.objectContaining({
-            body: expect.stringContaining('"notes":""'),
+            body: expect.stringContaining('"notes":" "'),
         }));
     });
 

--- a/tests/rBibliaWeb/Unit/App/ConsoleAppTest.php
+++ b/tests/rBibliaWeb/Unit/App/ConsoleAppTest.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\App;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\App\ConsoleApp;
+use Symfony\Component\Console\Application;
+
+class ConsoleAppTest extends TestCase
+{
+    public function testConsoleAppConstructRegistersImportCommand(): void
+    {
+        $settings = ['some_config' => 'value'];
+        $app = new ConsoleApp($settings);
+
+        $reflection = new \ReflectionClass(ConsoleApp::class);
+        $property = $reflection->getProperty('application');
+        /** @var Application $symfonyApp */
+        $symfonyApp = $property->getValue($app);
+
+        $this->assertInstanceOf(Application::class, $symfonyApp);
+        $this->assertTrue($symfonyApp->has('import'));
+        $this->assertSame($settings, $app->settings);
+    }
+}

--- a/tests/rBibliaWeb/Unit/App/WebAppTest.php
+++ b/tests/rBibliaWeb/Unit/App/WebAppTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\App;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\App\WebApp;
+
+class WebAppTest extends TestCase
+{
+    private array $serverBackup;
+
+    protected function setUp(): void
+    {
+        $this->serverBackup = $_SERVER;
+    }
+
+    protected function tearDown(): void
+    {
+        $_SERVER = $this->serverBackup;
+    }
+
+    private function getSettings(): array
+    {
+        return [
+            'security_query_limit' => 0,
+            'db_driver' => 'pdo_sqlite',
+            'db_name' => ':memory:',
+            'db_user' => '',
+            'db_pass' => '',
+            'db_host' => '',
+            'mailer' => [
+                'name' => 'Postman',
+                'smtp_host' => 'localhost',
+                'smtp_user' => 'user',
+                'smtp_password' => 'pass',
+                'smtp_port' => 25,
+                'smtp_auth' => true,
+            ],
+            'report' => [
+                'email_to_address' => 'to@example.com',
+                'email_to_name' => 'To Name',
+                'subject' => 'Subject',
+            ],
+        ];
+    }
+
+    public function testWebAppRoutesToBookList(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/api/en/book';
+
+        $app = new WebApp($this->getSettings());
+
+        $this->expectOutputRegex('("code":200)');
+        $this->expectOutputRegex('("gen":)');
+
+        try {
+            $app->run();
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testWebAppRoutesToNotFound(): void
+    {
+        $_SERVER['REQUEST_METHOD'] = 'GET';
+        $_SERVER['REQUEST_URI'] = '/api/en/nonexistent-route';
+
+        $app = new WebApp($this->getSettings());
+
+        $this->expectOutputRegex('("code":404)');
+        $this->expectOutputRegex('("message":"Not found")');
+
+        try {
+            $app->run();
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+}

--- a/tests/rBibliaWeb/Unit/Controller/ReportControllerTest.php
+++ b/tests/rBibliaWeb/Unit/Controller/ReportControllerTest.php
@@ -1,0 +1,131 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Controller\ReportController;
+use Symfony\Component\Mailer\Mailer;
+use Symfony\Component\Mailer\Transport\TransportInterface;
+use Symfony\Component\Mailer\Exception\TransportException;
+use Symfony\Component\Mime\Email;
+
+class ReportControllerTest extends TestCase
+{
+    private array $settings;
+
+    protected function setUp(): void
+    {
+        $this->settings = [
+            'mailer' => [
+                'smtp_user' => 'user',
+                'smtp_password' => 'pass',
+                'smtp_host' => 'host',
+                'smtp_port' => '25',
+                'name' => 'My Mailer',
+            ],
+            'report' => [
+                'email_to_address' => 'to@example.com',
+                'email_to_name' => 'To Name',
+                'subject' => 'Subject',
+            ],
+        ];
+    }
+
+    public function testSubmitSuccess(): void
+    {
+        $controller = new ReportController($this->settings);
+
+        $transportMock = $this->createMock(TransportInterface::class);
+        $transportMock->expects($this->once())
+            ->method('send')
+            ->with($this->callback(function (Email $email) {
+                $this->assertSame('to@example.com', $email->getTo()[0]->getAddress());
+                $this->assertSame('Subject', $email->getSubject());
+                $this->assertStringContainsString('Imię i nazwisko: John Doe', $email->getHtmlBody());
+                $this->assertStringContainsString('Adres zwrotny: john@example.com', $email->getHtmlBody());
+                $this->assertStringContainsString('Tłumaczenie: en_kjv', $email->getHtmlBody());
+                return true;
+            }));
+
+        $mailer = new Mailer($transportMock);
+
+        $reflection = new \ReflectionClass(ReportController::class);
+        $property = $reflection->getProperty('mailer');
+        $property->setValue($controller, $mailer);
+
+        $inputStream = json_encode([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'notes' => 'Some notes',
+            'content' => 'Corrected content',
+            'original_content' => 'Original content',
+            'translation' => 'en_kjv',
+            'book' => 'gen',
+            'chapter' => 1,
+            'verse' => 1,
+        ]);
+
+        $this->expectOutputRegex('("code":200)');
+
+        try {
+            $controller->submit('en', $inputStream);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testSubmitMailerThrowsTransportException(): void
+    {
+        $controller = new ReportController($this->settings);
+
+        $transportMock = $this->createMock(TransportInterface::class);
+        $transportMock->expects($this->once())
+            ->method('send')
+            ->willThrowException(new class('SMTP Error') extends TransportException {});
+
+        $mailer = new Mailer($transportMock);
+
+        $reflection = new \ReflectionClass(ReportController::class);
+        $property = $reflection->getProperty('mailer');
+        $property->setValue($controller, $mailer);
+
+        $inputStream = json_encode([
+            'name' => 'John Doe',
+            'email' => 'john@example.com',
+            'notes' => 'Some notes',
+            'content' => 'Corrected content',
+            'original_content' => 'Original content',
+            'translation' => 'en_kjv',
+            'book' => 'gen',
+            'chapter' => 1,
+            'verse' => 1,
+        ]);
+
+        $this->expectOutputRegex('("code":404)');
+        $this->expectOutputRegex('("message":"SMTP Error")');
+
+        try {
+            $controller->submit('en', $inputStream);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testSubmitInvalidInput(): void
+    {
+        $controller = new ReportController($this->settings);
+
+        $inputStream = json_encode([
+            'name' => 'John Doe',
+            // Missing email
+        ]);
+
+        $this->expectOutputRegex('("code":404)');
+
+        try {
+            $controller->submit('en', $inputStream);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+}

--- a/tests/rBibliaWeb/Unit/Controller/TranslationControllerTest.php
+++ b/tests/rBibliaWeb/Unit/Controller/TranslationControllerTest.php
@@ -1,0 +1,213 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Controller;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Controller\TranslationController;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Result;
+
+class TranslationControllerTest extends TestCase
+{
+    private array $settings;
+    private $dbMock;
+
+    protected function setUp(): void
+    {
+        $this->settings = [
+            'db_name' => 'test',
+            'db_user' => 'user',
+            'db_pass' => 'pass',
+            'db_host' => 'host',
+            'db_driver' => 'pdo_mysql',
+            'security_query_limit' => 5,
+        ];
+
+        $this->dbMock = $this->createMock(Connection::class);
+    }
+
+    private function getController(): TranslationController
+    {
+        $controller = new TranslationController($this->settings);
+        $reflection = new \ReflectionClass(TranslationController::class);
+        $property = $reflection->getProperty('db');
+        $property->setValue($controller, $this->dbMock);
+        return $controller;
+    }
+
+    public function testGetTranslationListSuccess(): void
+    {
+        $resultMock = $this->createMock(Result::class);
+        $resultMock->expects($this->exactly(2))
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(
+                [
+                    'id' => 'en_kjv',
+                    'language' => 'en',
+                    'name' => 'King James Version',
+                    'description' => 'KJV description',
+                    'date' => '1611',
+                ],
+                false
+            );
+
+        $this->dbMock->expects($this->once())
+            ->method('executeQuery')
+            ->willReturn($resultMock);
+
+        $controller = $this->getController();
+
+        $this->expectOutputRegex('("code":200)');
+        $this->expectOutputRegex('("id":"en_kjv")');
+
+        try {
+            $controller->getTranslationList('en');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testGetTranslationListDatabaseError(): void
+    {
+        $this->dbMock->expects($this->once())
+            ->method('executeQuery')
+            ->willThrowException(new class('DB Error') extends \Exception implements \Doctrine\DBAL\Exception {});
+
+        $controller = $this->getController();
+
+        $this->expectOutputRegex('("code":404)');
+
+        try {
+            $controller->getTranslationList('en');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testGetTranslationStructureByIdSuccess(): void
+    {
+        // 1. checkIfTranslationTableExists returns non-empty result (table exists)
+        $this->dbMock->expects($this->once())
+            ->method('fetchOne')
+            ->with($this->stringContains('SHOW TABLES LIKE'))
+            ->willReturn('data_en_kjv');
+
+        // 2. getTranslationStructureById query
+        $resultMock = $this->createMock(Result::class);
+        $resultMock->expects($this->exactly(3))
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(
+                ['book' => 'gen', 'chapter' => 1],
+                ['book' => 'gen', 'chapter' => 2],
+                false
+            );
+
+        $this->dbMock->expects($this->once())
+            ->method('executeQuery')
+            ->willReturn($resultMock);
+
+        $controller = $this->getController();
+
+        $this->expectOutputRegex('("code":200)');
+        $this->expectOutputRegex('("gen":\[1,2\])');
+
+        try {
+            $controller->getTranslationStructureById('en', 'en_kjv');
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+
+    public function testGetVersesSuccessAndTracksIP(): void
+    {
+        // 1. checkIfTranslationTableExists
+        $this->dbMock->method('fetchOne')
+            ->willReturnOnConsecutiveCalls(
+                'data_en_kjv', // table exists check
+                1 // ip tracking query_counter (ip long exists, counter = 1)
+            );
+
+        // 2. executeQuery calls:
+        // - DELETE from security
+        // - SELECT verse, content
+        // - UPDATE query_counter
+        $resultMock = $this->createMock(Result::class);
+        $resultMock->expects($this->exactly(3))
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(
+                ['verse' => 1, 'content' => 'In the beginning'],
+                ['verse' => 2, 'content' => 'And the earth'],
+                false
+            );
+
+        $this->dbMock->expects($this->exactly(3))
+            ->method('executeQuery')
+            ->willReturnCallback(function (string $sql) use ($resultMock) {
+                if (str_contains($sql, 'SELECT verse, content')) {
+                    return $resultMock;
+                }
+                return $this->createMock(Result::class);
+            });
+
+        $controller = $this->getController();
+
+        // Mock IP to be valid
+        putenv('REMOTE_ADDR=127.0.0.1');
+
+        $this->expectOutputRegex('("code":200)');
+        $this->expectOutputRegex('("1":"In the beginning")');
+
+        try {
+            $controller->getVerses('en', 'en_kjv', 'gen', 1);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        } finally {
+            putenv('REMOTE_ADDR=');
+        }
+    }
+
+    public function testGetVersesThrowsErrorWhenWrongIP(): void
+    {
+        $this->dbMock->method('fetchOne')
+            ->willReturn('data_en_kjv'); // table exists check
+
+        $controller = $this->getController();
+
+        // IP is empty
+        putenv('REMOTE_ADDR=0.0.0.0');
+
+        $this->expectOutputRegex('("code":404)');
+
+        try {
+            $controller->getVerses('en', 'en_kjv', 'gen', 1);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        } finally {
+            putenv('REMOTE_ADDR=');
+        }
+    }
+
+    public function testGetVersesLimitsExceeded(): void
+    {
+        // 1. checkIfTranslationTableExists
+        $this->dbMock->method('fetchOne')
+            ->willReturnOnConsecutiveCalls(
+                'data_en_kjv', // table exists check
+                5 // ip query_counter = 5 (limit is 5)
+            );
+
+        $controller = $this->getController();
+
+        putenv('REMOTE_ADDR=127.0.0.1');
+
+        $this->expectOutputRegex('("code":404)');
+
+        try {
+            $controller->getVerses('en', 'en_kjv', 'gen', 1);
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        } finally {
+            putenv('REMOTE_ADDR=');
+        }
+    }
+}

--- a/tests/rBibliaWeb/Unit/Exception/ExceptionTest.php
+++ b/tests/rBibliaWeb/Unit/Exception/ExceptionTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Exception;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Exception\LanguageNotSupportedException;
+use rBibliaWeb\Exception\VerseNotFoundException;
+
+class ExceptionTest extends TestCase
+{
+    public function testLanguageNotSupportedExceptionFormatting(): void
+    {
+        $exception = new LanguageNotSupportedException('fr');
+        $this->assertSame('Language [fr] is not supported', $exception->getMessage());
+    }
+
+    public function testVerseNotFoundExceptionFormatting(): void
+    {
+        $exception = new VerseNotFoundException('gen', 1, 1);
+        $this->assertSame('Verse [gen 1:1] was not found in the translation', $exception->getMessage());
+    }
+}

--- a/tests/rBibliaWeb/Unit/Provider/ReportProviderTest.php
+++ b/tests/rBibliaWeb/Unit/Provider/ReportProviderTest.php
@@ -1,0 +1,59 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Provider;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Provider\ReportProvider;
+use rBibliaWeb\Value\Report;
+
+class ReportProviderTest extends TestCase
+{
+    private const array VALID_PAYLOAD = [
+        'name' => 'John Doe',
+        'email' => 'john@example.com',
+        'notes' => 'Some notes',
+        'content' => 'Corrected content',
+        'original_content' => 'Original content',
+        'translation' => 'en_kjv',
+        'book' => 'gen',
+        'chapter' => 1,
+        'verse' => 1,
+    ];
+
+    public function testGetReportWithValidInputStream(): void
+    {
+        $inputStream = json_encode(self::VALID_PAYLOAD);
+        $provider = new ReportProvider('en', $inputStream);
+
+        $report = $provider->getReport();
+        $this->assertInstanceOf(Report::class, $report);
+        $this->assertSame('John Doe', $report->getName());
+        $this->assertSame('john@example.com', $report->getEmail());
+        $this->assertSame('en_kjv', $report->getTranslation());
+    }
+
+    public function testConstructorThrowsExceptionOnMalformedJson(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        // Expecting some JSON validation error message
+        new ReportProvider('en', 'malformed-json');
+    }
+
+    public function testConstructorThrowsExceptionOnMissingParameters(): void
+    {
+        $payload = self::VALID_PAYLOAD;
+        unset($payload['email']); // Remove required field
+
+        $this->expectException(\InvalidArgumentException::class);
+        new ReportProvider('en', json_encode($payload));
+    }
+
+    public function testConstructorThrowsExceptionOnEmptyStringParameters(): void
+    {
+        $payload = self::VALID_PAYLOAD;
+        $payload['name'] = ''; // Required parameter is empty
+
+        $this->expectException(\InvalidArgumentException::class);
+        new ReportProvider('en', json_encode($payload));
+    }
+}

--- a/tests/rBibliaWeb/Unit/Response/LandingPageResponseTest.php
+++ b/tests/rBibliaWeb/Unit/Response/LandingPageResponseTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Response;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Response\LandingPageResponse;
+
+class LandingPageResponseTest extends TestCase
+{
+    private string $assetsDir;
+    private string $cssFile;
+    private string $jsFile;
+
+    protected function setUp(): void
+    {
+        $this->assetsDir = APP_PATH_ASSETS;
+        if (!is_dir($this->assetsDir)) {
+            mkdir($this->assetsDir, 0777, true);
+        }
+
+        $this->cssFile = $this->assetsDir . '/app.css';
+        $this->jsFile = $this->assetsDir . '/app.js';
+
+        file_put_contents($this->cssFile, 'body { color: black; }');
+        file_put_contents($this->jsFile, 'console.log("hello");');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->cssFile)) {
+            unlink($this->cssFile);
+        }
+        if (file_exists($this->jsFile)) {
+            unlink($this->jsFile);
+        }
+        if (is_dir($this->assetsDir)) {
+            rmdir($this->assetsDir);
+        }
+    }
+
+    public function testRenderWithoutStatsClass(): void
+    {
+        $response = new LandingPageResponse();
+
+        $this->expectOutputRegex('(<!DOCTYPE html>)');
+        $this->expectOutputRegex('(<title>rBiblia Web</title>)');
+        $this->expectOutputRegex('(<!-- the Matomo code will be placed here only in prod env -->)');
+
+        $response->render();
+    }
+
+    public function testRenderWithStatsClass(): void
+    {
+        // Define temporary matomo class file
+        $tempStatsFile = __DIR__ . '/temp_matomo_class.php';
+        $classContent = <<<'PHP'
+<?php
+class matomo {
+    public static function getCode(int $id): string {
+        return "<!-- Matomo ID: " . $id . " -->";
+    }
+}
+PHP;
+        file_put_contents($tempStatsFile, $classContent);
+
+        $response = new LandingPageResponse();
+
+        $this->expectOutputRegex('(<!-- Matomo ID: 37 -->)');
+
+        try {
+            $response->render([
+                'stats_class' => $tempStatsFile
+            ]);
+        } finally {
+            if (file_exists($tempStatsFile)) {
+                unlink($tempStatsFile);
+            }
+        }
+    }
+}

--- a/tests/rBibliaWeb/Unit/Response/PageNotFoundResponseTest.php
+++ b/tests/rBibliaWeb/Unit/Response/PageNotFoundResponseTest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Response;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Response\PageNotFoundResponse;
+
+class PageNotFoundResponseTest extends TestCase
+{
+    public function testRenderOutputs404ResponseAndThrowsException(): void
+    {
+        $response = new PageNotFoundResponse();
+
+        $this->expectOutputRegex('("code":404)');
+        $this->expectOutputRegex('("message":"Not found")');
+
+        try {
+            $response->render();
+        } catch (\RuntimeException $e) {
+            $this->assertSame('Response sent', $e->getMessage());
+        }
+    }
+}

--- a/tests/rBibliaWeb/Unit/Value/AboutTest.php
+++ b/tests/rBibliaWeb/Unit/Value/AboutTest.php
@@ -1,0 +1,48 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Value;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Value\About;
+
+class AboutTest extends TestCase
+{
+    public function testGettersReturnCorrectValues(): void
+    {
+        $about = new About(
+            'translations/kjv.db',
+            'hash123',
+            'King James Version',
+            'KJV',
+            'en',
+            'Holy Bible KJV',
+            true,
+            '1611'
+        );
+
+        $this->assertSame('translations/kjv.db', $about->getFile());
+        $this->assertSame('hash123', $about->getHash());
+        $this->assertSame('King James Version', $about->getName());
+        $this->assertSame('KJV', $about->getShortname());
+        $this->assertSame('en', $about->getLanguage());
+        $this->assertSame('Holy Bible KJV', $about->getDescription());
+        $this->assertTrue($about->getAuthorised());
+        $this->assertSame('1611', $about->getDate());
+        $this->assertSame('kjv', $about->getId());
+    }
+
+    public function testDefaultValues(): void
+    {
+        $about = new About(
+            'translations/web.db',
+            'hash456',
+            'World English Bible',
+            'WEB',
+            'en'
+        );
+
+        $this->assertSame('', $about->getDescription());
+        $this->assertFalse($about->getAuthorised());
+        $this->assertSame('', $about->getDate());
+    }
+}

--- a/tests/rBibliaWeb/Unit/Value/ActionTest.php
+++ b/tests/rBibliaWeb/Unit/Value/ActionTest.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Value;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Value\Action;
+
+class ActionTest extends TestCase
+{
+    public function testCallWithStaticConstructorArguments(): void
+    {
+        $controller = new class {
+            public array $calledArgs = [];
+            public function run(array $args): void
+            {
+                $this->calledArgs = $args;
+            }
+        };
+
+        $action = new Action($controller, 'run', ['foo' => 'bar']);
+        $action->call(['ignored' => 'value']);
+
+        $this->assertSame(['foo' => 'bar'], $controller->calledArgs);
+    }
+
+    public function testCallWithDynamicArgumentsAndTypeConversion(): void
+    {
+        $controller = new class {
+            public array $calledArgs = [];
+            public function run(string $a, int $b): void
+            {
+                $this->calledArgs = [$a, $b];
+            }
+        };
+
+        $action = new Action($controller, 'run');
+        // '123' should be converted to integer 123
+        $action->call(['test', '123']);
+
+        $this->assertSame(['test', 123], $controller->calledArgs);
+    }
+}

--- a/tests/rBibliaWeb/Unit/Value/BodyTest.php
+++ b/tests/rBibliaWeb/Unit/Value/BodyTest.php
@@ -1,0 +1,41 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Value;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Value\Body;
+
+class BodyTest extends TestCase
+{
+    public function testBodyStartsEmpty(): void
+    {
+        $body = new Body();
+        $this->assertSame([], $body->getContent());
+        $this->assertSame(0, $body->getTotalVerseCount());
+    }
+
+    public function testAddVersePopulatesContentAndIncrementsCount(): void
+    {
+        $body = new Body();
+        $body->addVerse('gen', 1, 1, 'In the beginning');
+        $body->addVerse('gen', 1, 2, 'And the earth');
+        $body->addVerse('exo', 2, 1, 'And there went');
+
+        $expectedContent = [
+            'gen' => [
+                1 => [
+                    1 => 'In the beginning',
+                    2 => 'And the earth',
+                ]
+            ],
+            'exo' => [
+                2 => [
+                    1 => 'And there went',
+                ]
+            ],
+        ];
+
+        $this->assertSame($expectedContent, $body->getContent());
+        $this->assertSame(3, $body->getTotalVerseCount());
+    }
+}

--- a/tests/rBibliaWeb/Unit/Value/ReportTest.php
+++ b/tests/rBibliaWeb/Unit/Value/ReportTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Value;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Value\Report;
+
+class ReportTest extends TestCase
+{
+    private const array VALID_DATA = [
+        'name' => 'John Doe',
+        'email' => 'john@example.com',
+        'notes' => "Line 1\nLine 2",
+        'content' => "Correction 1\nCorrection 2",
+        'original_content' => 'Original Text',
+        'translation' => 'en_kjv',
+        'book' => 'gen',
+        'chapter' => 1,
+        'verse' => 1,
+    ];
+
+    public function testGettersReturnCorrectValues(): void
+    {
+        $report = new Report(self::VALID_DATA);
+
+        $this->assertSame('John Doe', $report->getName());
+        $this->assertSame('john@example.com', $report->getEmail());
+        $this->assertSame("Line 1<br />\nLine 2", $report->getNotes());
+        $this->assertSame("Correction 1<br />\nCorrection 2", $report->getContent());
+        $this->assertSame('Original Text', $report->getOriginalContent());
+        $this->assertSame('en_kjv', $report->getTranslation());
+        $this->assertSame('gen', $report->getBook());
+        $this->assertSame('1', $report->getChapter());
+        $this->assertSame('1', $report->getVerse());
+    }
+
+    public function testGetIPWithRemoteAddr(): void
+    {
+        $report = new Report(self::VALID_DATA);
+
+        putenv('HTTP_X_FORWARDED_FOR=');
+        putenv('REMOTE_ADDR=192.168.1.1');
+        $this->assertSame('192.168.1.1', $report->getIP());
+    }
+
+    public function testGetIPWithForwardedFor(): void
+    {
+        $report = new Report(self::VALID_DATA);
+
+        putenv('HTTP_X_FORWARDED_FOR=10.0.0.1');
+        putenv('REMOTE_ADDR=192.168.1.1');
+        $this->assertSame('10.0.0.1', $report->getIP());
+
+        // Cleanup
+        putenv('HTTP_X_FORWARDED_FOR=');
+        putenv('REMOTE_ADDR=');
+    }
+}

--- a/tests/rBibliaWeb/Unit/Value/TranslationTest.php
+++ b/tests/rBibliaWeb/Unit/Value/TranslationTest.php
@@ -1,0 +1,75 @@
+<?php declare(strict_types=1);
+
+namespace rBibliaWeb\Unit\Value;
+
+use PHPUnit\Framework\TestCase;
+use rBibliaWeb\Exception\VerseNotFoundException;
+use rBibliaWeb\Value\About;
+use rBibliaWeb\Value\Body;
+use rBibliaWeb\Value\Translation;
+
+class TranslationTest extends TestCase
+{
+    private About $about;
+    private Body $body;
+    private Translation $translation;
+
+    protected function setUp(): void
+    {
+        $this->about = new About(
+            'translations/kjv.db',
+            'hash123',
+            'King James Version',
+            'KJV',
+            'en'
+        );
+
+        $this->body = new Body();
+        $this->body->addVerse('gen', 1, 1, 'In the beginning');
+        $this->body->addVerse('gen', 1, 2, 'And the earth');
+        $this->body->addVerse('exo', 1, 1, 'Now these are');
+
+        $this->translation = new Translation($this->about, $this->body);
+    }
+
+    public function testGetAbout(): void
+    {
+        $this->assertSame($this->about, $this->translation->getAbout());
+    }
+
+    public function testGetTotalVerseCount(): void
+    {
+        $this->assertSame(3, $this->translation->getTotalVerseCount());
+    }
+
+    public function testGetBooks(): void
+    {
+        $this->assertSame(['gen', 'exo'], $this->translation->getBooks());
+    }
+
+    public function testGetChapters(): void
+    {
+        $this->assertSame([1], $this->translation->getChapters('gen'));
+    }
+
+    public function testGetVerses(): void
+    {
+        $this->assertSame([1, 2], $this->translation->getVerses('gen', 1));
+    }
+
+    public function testGetVerseAtReturnsCorrectVerse(): void
+    {
+        $verse = $this->translation->getVerseAt('gen', 1, 2);
+        $this->assertSame('gen', $verse->getBookId());
+        $this->assertSame(1, $verse->getChapterId());
+        $this->assertSame(2, $verse->getVerseId());
+        $this->assertSame('And the earth', $verse->getContent());
+    }
+
+    public function testGetVerseAtThrowsVerseNotFoundException(): void
+    {
+        $this->expectException(VerseNotFoundException::class);
+        $this->expectExceptionMessage('Verse [gen 1:3] was not found in the translation');
+        $this->translation->getVerseAt('gen', 1, 3);
+    }
+}


### PR DESCRIPTION
This PR fixes the issue where report verse contents were empty when switching languages, and implements full unit/integration test coverage for the backend PHP classes.